### PR TITLE
initialize headers map in Transport

### DIFF
--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -42,6 +42,7 @@ func NewTransport(appID, apiKey string) *Transport {
   transport.apiKey = apiKey
   tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
   transport.httpClient = &http.Client{Transport: tr}
+  transport.headers = make(map[string]string)
   //transport.hosts = [3]string{"https://" + appID + suffix[perm[0]], "https://" + appID + suffix[perm[1]], "https://" + appID + suffix[perm[2]], }
   transport.hosts = make([]string, 3)
   transport.hosts[0] = appID + "-1.algolianet.com"
@@ -60,6 +61,7 @@ func NewTransportWithHosts(appID, apiKey string, hosts []string) *Transport {
   transport.apiKey = apiKey
   tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
   transport.httpClient = &http.Client{Transport: tr}
+  transport.headers = make(map[string]string)
   transport.hosts = hosts
   transport.hostsProvided = true
   transport.connectTimeout = 2 * time.Second
@@ -188,7 +190,7 @@ func (t *Transport) buildRequest(method, host, path string, body interface{}) (*
 func (t *Transport) addHeaders(req *http.Request) *http.Request {
   req.Header.Add("X-Algolia-API-Key", t.apiKey)
   req.Header.Add("X-Algolia-Application-Id", t.appID)
-  req.Header.Add("Connection", "keep-alive") 
+  req.Header.Add("Connection", "keep-alive")
   req.Header.Add("User-Agent", "Algolia for go " + version)
   for key := range t.headers {
     req.Header.Add(key, t.headers[key])
@@ -205,7 +207,7 @@ func (t *Transport) handleResponse(resp *http.Response) (interface{}, error) {
   var jsonResp interface{}
   err = json.Unmarshal(res, &jsonResp)
   if err != nil {
-    return nil, errors.New("Invalid JSON in the response") 
+    return nil, errors.New("Invalid JSON in the response")
   }
   if resp.StatusCode >= 200 && resp.StatusCode < 300 {
     return jsonResp, nil


### PR DESCRIPTION
This PR fixes a bug that caused me a panic when calling `client.SetExtraHeader`.

I'm implementing a CLI search that uses a token generated via  a `createCollectionScopedKey` call. I still can't get the faceting to work, but this fix at least helps my panic. I

```
panic: runtime error: assignment to entry in nil map

goroutine 16 [running]:
runtime.panic(0x2edde0, 0x4db7f3)
	/usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/algolia/algoliasearch-client-go/algoliasearch.(*Client).SetExtraHeader(0xc2080381b0, 0x363630, 0x19, 0xc20801aaf0, 0x41)
	/Users/csquared/projects/go/src/github.com/algolia/algoliasearch-client-go/algoliasearch/Client.go:29 +0x8d
main.(*CLI).Search(0xc208074b60, 0xc208000e88, 0x4)
	/Users/csquared/projects/go/src/github.com/usecanvas/canvas/search.go:24 +0x33a
main.main()
	/Users/csquared/projects/go/src/github.com/usecanvas/canvas/main.go:72 +0x990
```