### PR TITLE
Search result struct

### DIFF
--- a/algoliasearch/Client_test.go
+++ b/algoliasearch/Client_test.go
@@ -6,699 +6,696 @@ import "testing"
 import "time"
 
 func safeName(name string) string {
-  travis, haveTravis := syscall.Getenv("TRAVIS");
-  buildId, haveBuildId := syscall.Getenv("TRAVIS_JOB_NUMBER");
-  if !haveTravis || !haveBuildId || travis != "true" {
-    return name;
-  }
-  
-  return name + "_travis-" + buildId;
+	travis, haveTravis := syscall.Getenv("TRAVIS")
+	buildId, haveBuildId := syscall.Getenv("TRAVIS_JOB_NUMBER")
+	if !haveTravis || !haveBuildId || travis != "true" {
+		return name
+	}
+
+	return name + "_travis-" + buildId
 }
 
 func initTest(t *testing.T) (*Client, *Index) {
-  appID, haveAppID := syscall.Getenv("ALGOLIA_APPLICATION_ID")
-  apiKey, haveApiKey := syscall.Getenv("ALGOLIA_API_KEY")
-  if !haveApiKey || !haveAppID {
-    t.Fatalf("Need ALGOLIA_APPLICATION_ID and ALGOLIA_API_KEY")
-  }
-  client := NewClient(appID, apiKey)
-  client.SetTimeout(1000, 10000)
-  hosts := make([]string, 3)
-  hosts[0] = appID + "-1.algolia.net"
-  hosts[1] = appID + "-2.algolia.net"
-  hosts[2] = appID + "-3.algolia.net"
-  client = NewClientWithHosts(appID, apiKey, hosts)
-  index := client.InitIndex(safeName("àlgol?à-go"))
+	appID, haveAppID := syscall.Getenv("ALGOLIA_APPLICATION_ID")
+	apiKey, haveApiKey := syscall.Getenv("ALGOLIA_API_KEY")
+	if !haveApiKey || !haveAppID {
+		t.Fatalf("Need ALGOLIA_APPLICATION_ID and ALGOLIA_API_KEY")
+	}
+	client := NewClient(appID, apiKey)
+	client.SetTimeout(1000, 10000)
+	hosts := make([]string, 3)
+	hosts[0] = appID + "-1.algolia.net"
+	hosts[1] = appID + "-2.algolia.net"
+	hosts[2] = appID + "-3.algolia.net"
+	client = NewClientWithHosts(appID, apiKey, hosts)
+	index := client.InitIndex(safeName("àlgol?à-go"))
 
-  return client, index
+	return client, index
 }
 
 func shouldHave(json interface{}, attr, msg string, t *testing.T) {
-  _, ok := json.(map[string]interface{})[attr]
-  if !ok  {
-    t.Fatalf(msg + ", expected attribute: " + attr)
-  }
+	_, ok := json.(map[string]interface{})[attr]
+	if !ok {
+		t.Fatalf(msg + ", expected attribute: " + attr)
+	}
 }
 
 func shouldNotHave(json interface{}, attr, msg string, t *testing.T) {
-  _, ok := json.(map[string]interface{})[attr]
-  if ok  {
-    t.Fatalf(msg + ", unexpected attribute: " + attr)
-  }
+	_, ok := json.(map[string]interface{})[attr]
+	if ok {
+		t.Fatalf(msg + ", unexpected attribute: " + attr)
+	}
 }
 
 func shouldStr(json interface{}, attr, value, msg string, t *testing.T) {
-  resp, ok := json.(map[string]interface{})[attr]
-  if !ok || value != resp.(string) {
-    t.Fatalf(msg + ", expected: " + value + " have: " + resp.(string))
-  }
+	resp, ok := json.(map[string]interface{})[attr]
+	if !ok || value != resp.(string) {
+		t.Fatalf(msg + ", expected: " + value + " have: " + resp.(string))
+	}
 }
 
 func shouldFloat(json interface{}, attr string, value float64, msg string, t *testing.T) {
-  resp, ok := json.(map[string]interface{})[attr]
-  if !ok || value != resp.(float64) {
-    t.Fatalf(msg + ", expected: " + strconv.FormatFloat(value, 'f', -1, 64) + " have: " + strconv.FormatFloat(resp.(float64), 'f', -1, 64))
-  }
+	resp, ok := json.(map[string]interface{})[attr]
+	if !ok || value != resp.(float64) {
+		t.Fatalf(msg + ", expected: " + strconv.FormatFloat(value, 'f', -1, 64) + " have: " + strconv.FormatFloat(resp.(float64), 'f', -1, 64))
+	}
 }
 
 func shouldContainString(json interface{}, attr string, value string, msg string, t *testing.T) {
-  array := json.([]interface{})
-  for i := range array {
-    val, ok := array[i].(map[string]interface{})[attr]
-    if ok && value == val.(string) {
-      return
-    }
-  }
-  t.Fatalf(msg + ", expected: " + value + " in the array.")
+	array := json.([]interface{})
+	for i := range array {
+		val, ok := array[i].(map[string]interface{})[attr]
+		if ok && value == val.(string) {
+			return
+		}
+	}
+	t.Fatalf(msg + ", expected: " + value + " in the array.")
 }
 
 func shouldNotContainString(json interface{}, attr string, value string, msg string, t *testing.T) {
-  array := json.([]interface{})
-  for i := range array {
-    val, ok := array[i].(map[string]interface{})[attr]
-    if ok && value == val.(string) {
-      t.Fatalf(msg + ", expected: " + value + " in the array.")
-    }
-  }
+	array := json.([]interface{})
+	for i := range array {
+		val, ok := array[i].(map[string]interface{})[attr]
+		if ok && value == val.(string) {
+			t.Fatalf(msg + ", expected: " + value + " in the array.")
+		}
+	}
 }
 
 func TestClear(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err = index.Clear()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  index.WaitTask(resp)
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 0, "Unable to clear the index", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err = index.Clear()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	index.WaitTask(resp)
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 0, "Unable to clear the index", t)
+	index.Delete()
 }
 
 func TestAddObject(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  _, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 2, "Unable to clear the index", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	_, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 2, "Unable to clear the index", t)
+	index.Delete()
 }
 
 func TestUpdateObject(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  _, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  object["name"] = "Roger"
-  resp, err := index.UpdateObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  hits := results.(map[string]interface{})["hits"]
-  shouldStr(hits.([]interface{})[0], "name", "Roger", "Unable to update an object", t)
-  shouldNotHave(hits.([]interface{})[0], "job", "Unable to update an object", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	_, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	object["name"] = "Roger"
+	resp, err := index.UpdateObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	hits := results.(map[string]interface{})["hits"]
+	shouldStr(hits.([]interface{})[0], "name", "Roger", "Unable to update an object", t)
+	shouldNotHave(hits.([]interface{})[0], "job", "Unable to update an object", t)
+	index.Delete()
 }
 
 func TestPartialUpdateObject(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["job"] = "Knight"
-  object["objectID"] = "àlgol?à"
-  _, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  delete(object, "job")
-  object["name"] = "Roger"
-  resp, err := index.PartialUpdateObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  hits := results.(map[string]interface{})["hits"]
-  shouldStr(hits.([]interface{})[0], "name", "Roger", "Unable to update an object", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["job"] = "Knight"
+	object["objectID"] = "àlgol?à"
+	_, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	delete(object, "job")
+	object["name"] = "Roger"
+	resp, err := index.PartialUpdateObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	hits := results.(map[string]interface{})["hits"]
+	shouldStr(hits.([]interface{})[0], "name", "Roger", "Unable to update an object", t)
+	index.Delete()
 }
 
-
 func TestGetObject(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err = index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  obj, err := index.GetObject("àlgol?à")
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldStr(obj, "name", "John Snow", "Unable to update an object", t)
-  obj, err = index.GetObject("àlgol?à", "name")
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldStr(obj, "name", "John Snow", "Unable to update an object", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err = index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	obj, err := index.GetObject("àlgol?à")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldStr(obj, "name", "John Snow", "Unable to update an object", t)
+	obj, err = index.GetObject("àlgol?à", "name")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldStr(obj, "name", "John Snow", "Unable to update an object", t)
+	index.Delete()
 }
 
 func TestGetObjectError(t *testing.T) {
-  _, index := initTest(t)
-  _, err := index.GetObject("", "test", "test")
-  if err == nil {
-    t.Fatalf("GetObject variadic args checking failed")
-  }
+	_, index := initTest(t)
+	_, err := index.GetObject("", "test", "test")
+	if err == nil {
+		t.Fatalf("GetObject variadic args checking failed")
+	}
 }
 
 func TestGetObjects(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "Los Angeles"
-  object["objectID"] = "1"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  object = make(map[string]interface{})
-  object["name"] = "San Francisco"
-  object["objectID"] = "2"
-  resp, err = index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  res, err := index.GetObjects("1", "2")
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldStr(res.(map[string]interface{})["results"].([]interface{})[0], "name", "Los Angeles", "Unable to get objects", t)
-  shouldStr(res.(map[string]interface{})["results"].([]interface{})[1], "name", "San Francisco", "Unable to get objects", t)
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "Los Angeles"
+	object["objectID"] = "1"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	object = make(map[string]interface{})
+	object["name"] = "San Francisco"
+	object["objectID"] = "2"
+	resp, err = index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	res, err := index.GetObjects("1", "2")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldStr(res.(map[string]interface{})["results"].([]interface{})[0], "name", "Los Angeles", "Unable to get objects", t)
+	shouldStr(res.(map[string]interface{})["results"].([]interface{})[1], "name", "San Francisco", "Unable to get objects", t)
 
-  index.Delete()
+	index.Delete()
 }
 
-
 func TestDeleteObject(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err = index.DeleteObject("àlgol?à")
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 0, "Unable to clear the index", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err = index.DeleteObject("àlgol?à")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 0, "Unable to clear the index", t)
+	index.Delete()
 }
 
 func TestSetSettings(t *testing.T) {
-  _, index := initTest(t)
-  settings := make(map[string]interface{})
-  settings["hitsPerPage"] = 30
-  resp, err := index.SetSettings(settings)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  settingsChanged, err := index.GetSettings()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(settingsChanged, "hitsPerPage", 30, "Unable to change setting", t)
-  index.Delete()
+	_, index := initTest(t)
+	settings := make(map[string]interface{})
+	settings["hitsPerPage"] = 30
+	resp, err := index.SetSettings(settings)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	settingsChanged, err := index.GetSettings()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(settingsChanged, "hitsPerPage", 30, "Unable to change setting", t)
+	index.Delete()
 }
 
 func TestGetLogs(t *testing.T) {
-  client, _ := initTest(t)
-  logs, err := client.GetLogs(0, 100, "all")
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldHave(logs, "logs", "Unable to get logs", t)
+	client, _ := initTest(t)
+	logs, err := client.GetLogs(0, 100, "all")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldHave(logs, "logs", "Unable to get logs", t)
 }
 
 func TestBrowse(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  items, err := index.Browse(1, 1)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldHave(items, "hits", "Unable to browse index", t)
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	items, err := index.Browse(1, 1)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldHave(items, "hits", "Unable to browse index", t)
+	index.Delete()
 }
 
 func TestBrowseWithCursor(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  items, err := index.BrowseAll(map[string]interface{}{"query": ""})
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  hit, err := items.Next()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldStr(hit, "name", "John Snow", "Unable to browse index with cursor", t)
-  hit, err = items.Next()
-  if err == nil {
-    t.Fatalf("Should contains only one elt")
-  }
-  index.Delete()
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	items, err := index.BrowseAll(map[string]interface{}{"query": ""})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	hit, err := items.Next()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldStr(hit, "name", "John Snow", "Unable to browse index with cursor", t)
+	hit, err = items.Next()
+	if err == nil {
+		t.Fatalf("Should contains only one elt")
+	}
+	index.Delete()
 }
 
 func TestQuery(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  params := make(map[string]interface{})
-  params["attributesToRetrieve"] = "*"
-  params["getRankingInfo"] = 1
-  results, err := index.Search("", params)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 1, "Unable to query an index", t)
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	params := make(map[string]interface{})
+	params["attributesToRetrieve"] = "*"
+	params["getRankingInfo"] = 1
+	results, err := index.Search("", params)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 1, "Unable to query an index", t)
 }
 
 func TestCopy(t *testing.T) {
-  client, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  _, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err := index.Copy(safeName("àlgo?à2-go"))
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  indexCopy := client.InitIndex(safeName("àlgo?à2-go"))
-  results, err := indexCopy.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 1, "Unable to copy an index", t)
-  index.Delete()
-  indexCopy.Delete()
+	client, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	_, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err := index.Copy(safeName("àlgo?à2-go"))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	indexCopy := client.InitIndex(safeName("àlgo?à2-go"))
+	results, err := indexCopy.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 1, "Unable to copy an index", t)
+	index.Delete()
+	indexCopy.Delete()
 }
 
 func TestMove(t *testing.T) {
-  client, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  object["objectID"] = "àlgol?à"
-  task, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err := index.Move(safeName("àlgo?à2-go"))
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  indexMove := client.InitIndex(safeName("àlgo?à2-go"))
-  results, err := indexMove.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 1, "Unable to move an index", t)
-  indexMove.Delete()
+	client, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	object["objectID"] = "àlgol?à"
+	task, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err := index.Move(safeName("àlgo?à2-go"))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	indexMove := client.InitIndex(safeName("àlgo?à2-go"))
+	results, err := indexMove.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 1, "Unable to move an index", t)
+	indexMove.Delete()
 }
 
 func TestAddIndexKey(t *testing.T) {
-  _, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
+	_, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 
-  acl := []string{"search"}
-  newKey, err := index.AddKey(acl, 300, 100, 100)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  time.Sleep(5000 * time.Millisecond)
-  key, err := index.GetKey(newKey.(map[string]interface{})["key"].(string))
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldStr(key, "value", newKey.(map[string]interface{})["key"].(string), "Unable to get a key", t)
-  list, err := index.ListKeys()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
+	acl := []string{"search"}
+	newKey, err := index.AddKey(acl, 300, 100, 100)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	time.Sleep(5000 * time.Millisecond)
+	key, err := index.GetKey(newKey.(map[string]interface{})["key"].(string))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldStr(key, "value", newKey.(map[string]interface{})["key"].(string), "Unable to get a key", t)
+	list, err := index.ListKeys()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
 
-  _, err = index.UpdateKey(newKey.(map[string]interface{})["key"].(string), []string{"addObject"}, 300, 100, 100)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  time.Sleep(5000 * time.Millisecond)
-  list, err = index.ListKeys()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
+	_, err = index.UpdateKey(newKey.(map[string]interface{})["key"].(string), []string{"addObject"}, 300, 100, 100)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	time.Sleep(5000 * time.Millisecond)
+	list, err = index.ListKeys()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
 
-  _, err = index.DeleteKey(newKey.(map[string]interface{})["key"].(string))
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  time.Sleep(5000 * time.Millisecond)
-  list, err = index.ListKeys()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldNotContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
-  index.Delete() 
+	_, err = index.DeleteKey(newKey.(map[string]interface{})["key"].(string))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	time.Sleep(5000 * time.Millisecond)
+	list, err = index.ListKeys()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldNotContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
+	index.Delete()
 }
 
 func TestAddKey(t *testing.T) {
-  client, index := initTest(t)
-  acl := []string{"search"}
-  indexes := []string{index.name}
-  newKey, err := client.AddKey(acl, indexes, 300, 100, 100)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  time.Sleep(5000 * time.Millisecond)
-  key, err := client.GetKey(newKey.(map[string]interface{})["key"].(string))
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldStr(key, "value", newKey.(map[string]interface{})["key"].(string), "Unable to get a key", t)
+	client, index := initTest(t)
+	acl := []string{"search"}
+	indexes := []string{index.name}
+	newKey, err := client.AddKey(acl, indexes, 300, 100, 100)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	time.Sleep(5000 * time.Millisecond)
+	key, err := client.GetKey(newKey.(map[string]interface{})["key"].(string))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldStr(key, "value", newKey.(map[string]interface{})["key"].(string), "Unable to get a key", t)
 
-  _, err = client.UpdateKey(newKey.(map[string]interface{})["key"].(string), []string{"addObject"}, indexes, 300, 100, 100)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  time.Sleep(5000 * time.Millisecond)
+	_, err = client.UpdateKey(newKey.(map[string]interface{})["key"].(string), []string{"addObject"}, indexes, 300, 100, 100)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	time.Sleep(5000 * time.Millisecond)
 
-  list, err := client.ListKeys()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
-  _, err = client.DeleteKey(newKey.(map[string]interface{})["key"].(string))
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  time.Sleep(5000 * time.Millisecond)
-  list, err = client.ListKeys()
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldNotContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
+	list, err := client.ListKeys()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
+	_, err = client.DeleteKey(newKey.(map[string]interface{})["key"].(string))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	time.Sleep(5000 * time.Millisecond)
+	list, err = client.ListKeys()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldNotContainString(list.(map[string]interface{})["keys"], "value", newKey.(map[string]interface{})["key"].(string), "Unable to add a key", t)
 }
 
 func TestAddObjects(t *testing.T) {
-  _, index := initTest(t)
-  objects := make([]interface{}, 2)
+	_, index := initTest(t)
+	objects := make([]interface{}, 2)
 
-  object := make(map[string]interface{})
-  object["name"] = "John"
-  object["city"] = "San Francisco"
-  objects[0] = object
+	object := make(map[string]interface{})
+	object["name"] = "John"
+	object["city"] = "San Francisco"
+	objects[0] = object
 
-  object = make(map[string]interface{})
-  object["name"] = "Roger"
-  object["city"] = "New York"
-  objects[1] = object
-  task, err := index.AddObjects(objects)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  index.WaitTask(task)
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 2, "Unable to add objects", t)
-  index.Delete()
+	object = make(map[string]interface{})
+	object["name"] = "Roger"
+	object["city"] = "New York"
+	objects[1] = object
+	task, err := index.AddObjects(objects)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	index.WaitTask(task)
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 2, "Unable to add objects", t)
+	index.Delete()
 }
 
 func TestUpdateObjects(t *testing.T) {
-  _, index := initTest(t)
-  objects := make([]interface{}, 2)
+	_, index := initTest(t)
+	objects := make([]interface{}, 2)
 
-  object := make(map[string]interface{})
-  object["name"] = "John"
-  object["city"] = "San Francisco"
-  object["objectID"] = "àlgo?à-1"
-  objects[0] = object
+	object := make(map[string]interface{})
+	object["name"] = "John"
+	object["city"] = "San Francisco"
+	object["objectID"] = "àlgo?à-1"
+	objects[0] = object
 
-  object = make(map[string]interface{})
-  object["name"] = "Roger"
-  object["city"] = "New York"
-  object["objectID"] = "àlgo?à-2"
-  objects[1] = object
-  task, err := index.UpdateObjects(objects)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 2, "Unable to update objects", t)
-  index.Delete()
+	object = make(map[string]interface{})
+	object["name"] = "Roger"
+	object["city"] = "New York"
+	object["objectID"] = "àlgo?à-2"
+	objects[1] = object
+	task, err := index.UpdateObjects(objects)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 2, "Unable to update objects", t)
+	index.Delete()
 }
 
 func TestPartialUpdateObjects(t *testing.T) {
-  _, index := initTest(t)
-  objects := make([]interface{}, 2)
+	_, index := initTest(t)
+	objects := make([]interface{}, 2)
 
-  object := make(map[string]interface{})
-  object["name"] = "John"
-  object["objectID"] = "àlgo?à-1"
-  objects[0] = object
+	object := make(map[string]interface{})
+	object["name"] = "John"
+	object["objectID"] = "àlgo?à-1"
+	objects[0] = object
 
-  object = make(map[string]interface{})
-  object["name"] = "Roger"
-  object["objectID"] = "àlgo?à-2"
-  objects[1] = object
-  task, err := index.PartialUpdateObjects(objects)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 2, "Unable to partial update objects", t)
-  index.Delete()
+	object = make(map[string]interface{})
+	object["name"] = "Roger"
+	object["objectID"] = "àlgo?à-2"
+	objects[1] = object
+	task, err := index.PartialUpdateObjects(objects)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 2, "Unable to partial update objects", t)
+	index.Delete()
 }
 
 func TestDeleteObjects(t *testing.T) {
-  _, index := initTest(t)
-  objects := make([]interface{}, 2)
+	_, index := initTest(t)
+	objects := make([]interface{}, 2)
 
-  object := make(map[string]interface{})
-  object["name"] = "John"
-  object["objectID"] = "àlgo?à-1"
-  objects[0] = object
+	object := make(map[string]interface{})
+	object["name"] = "John"
+	object["objectID"] = "àlgo?à-1"
+	objects[0] = object
 
-  object = make(map[string]interface{})
-  object["name"] = "Roger"
-  object["objectID"] = "àlgo?à-2"
-  objects[1] = object
-  task, err := index.PartialUpdateObjects(objects)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  objectIDs := []string{"àlgo?à-1", "àlgo?à-2"}
-  task, err = index.DeleteObjects(objectIDs)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 0, "Unable to partial update objects", t)
-  index.Delete()
+	object = make(map[string]interface{})
+	object["name"] = "Roger"
+	object["objectID"] = "àlgo?à-2"
+	objects[1] = object
+	task, err := index.PartialUpdateObjects(objects)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	objectIDs := []string{"àlgo?à-1", "àlgo?à-2"}
+	task, err = index.DeleteObjects(objectIDs)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 0, "Unable to partial update objects", t)
+	index.Delete()
 }
 
 func TestDeleteByQuery(t *testing.T) {
-  _, index := initTest(t)
-  objects := make([]interface{}, 3)
+	_, index := initTest(t)
+	objects := make([]interface{}, 3)
 
-  object := make(map[string]interface{})
-  object["name"] = "San Jose"
-  objects[0] = object
+	object := make(map[string]interface{})
+	object["name"] = "San Jose"
+	objects[0] = object
 
-  object = make(map[string]interface{})
-  object["name"] = "Washington"
-  objects[1] = object
+	object = make(map[string]interface{})
+	object["name"] = "Washington"
+	objects[1] = object
 
-  object = make(map[string]interface{})
-  object["name"] = "San Francisco"
-  objects[2] = object
-  task, err := index.AddObjects(objects)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.DeleteByQuery("San", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  results, err := index.Search("", nil)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(results, "nbHits", 1, "Unable to delete by query", t)
-  index.Delete()
+	object = make(map[string]interface{})
+	object["name"] = "San Francisco"
+	objects[2] = object
+	task, err := index.AddObjects(objects)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.DeleteByQuery("San", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	results, err := index.Search("", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(results, "nbHits", 1, "Unable to delete by query", t)
+	index.Delete()
 }
-
 
 /*
 func TestKeepAlive(t *testing.T) {
@@ -717,82 +714,81 @@ func TestKeepAlive(t *testing.T) {
 }*/
 
 func TestGenerateSecuredApiKey(t *testing.T) {
-  client, _ := initTest(t)
-  query := make(map[string]interface{})
-  query["hitsPerPage"] = 20
-  key, _ := client.GenerateSecuredApiKey("my_api_key", query)
-  key, _ = client.GenerateSecuredApiKey("my_api_key", "(public,user1)")
-  if "1fd74b206c64fb49fdcd7a5f3004356cd3bdc9d9aba8733656443e64daafc417" != key {
-    t.Fatalf("Invalid key: " + key)
-  }
-  key, _ = client.GenerateSecuredApiKey("my_api_key", "(public,user1)", "user1")
-  if "5d50c79541de552654e3fad2091c38a457b56992d61b342fb09da8c42fbbe043" != key {
-    t.Fatalf("Invalid key: " + key)
-  }
+	client, _ := initTest(t)
+	query := make(map[string]interface{})
+	query["hitsPerPage"] = 20
+	key, _ := client.GenerateSecuredApiKey("my_api_key", query)
+	key, _ = client.GenerateSecuredApiKey("my_api_key", "(public,user1)")
+	if "1fd74b206c64fb49fdcd7a5f3004356cd3bdc9d9aba8733656443e64daafc417" != key {
+		t.Fatalf("Invalid key: " + key)
+	}
+	key, _ = client.GenerateSecuredApiKey("my_api_key", "(public,user1)", "user1")
+	if "5d50c79541de552654e3fad2091c38a457b56992d61b342fb09da8c42fbbe043" != key {
+		t.Fatalf("Invalid key: " + key)
+	}
 }
 
 func TestMultipleQueries(t *testing.T) {
-  client, index := initTest(t)
-  object := make(map[string]interface{})
-  object["name"] = "John Snow"
-  resp, err := index.AddObject(object)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  resp, err = index.WaitTask(resp)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
+	client, index := initTest(t)
+	object := make(map[string]interface{})
+	object["name"] = "John Snow"
+	resp, err := index.AddObject(object)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	resp, err = index.WaitTask(resp)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 
-  query := make(map[string]interface{})
-  query["indexName"] = safeName("àlgol?à-go")
-  query["query"] = ""
-  queries := make([]interface{}, 1)
-  queries[0] = query
-  res, err := client.MultipleQueries(queries)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(res.(map[string]interface{})["results"].([]interface{})[0], "nbHits", 1, "Unable to query multiple indexes", t)
-  index.Delete()
+	query := make(map[string]interface{})
+	query["indexName"] = safeName("àlgol?à-go")
+	query["query"] = ""
+	queries := make([]interface{}, 1)
+	queries[0] = query
+	res, err := client.MultipleQueries(queries)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(res.(map[string]interface{})["results"].([]interface{})[0], "nbHits", 1, "Unable to query multiple indexes", t)
+	index.Delete()
 }
 
 func TestFacets(t *testing.T) {
-  _, index := initTest(t)
-  
-  settings := map[string]interface{}{"attributesForFacetting" : []string{"f", "g"}}
-  _, err := index.SetSettings(settings)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
+	_, index := initTest(t)
 
-  _, err = index.AddObject(map[string]interface{}{"f": "f1", "g":"g1"})
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.AddObject(map[string]interface{}{"f": "f1", "g":"g2"})
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.AddObject(map[string]interface{}{"f": "f2", "g":"g2"})
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  task, err := index.AddObject(map[string]interface{}{"f": "f3", "g":"g2"})
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  _, err = index.WaitTask(task)
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
+	settings := map[string]interface{}{"attributesForFacetting": []string{"f", "g"}}
+	_, err := index.SetSettings(settings)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 
-  res, err := index.Search("", map[string]interface{}{"facets": "f", "facetFilters":[]string {"f:f1"}})
-  if err != nil {
-    t.Fatalf(err.Error())
-  }
-  shouldFloat(res, "nbHits", 2, "Unable to filter facets", t)
+	_, err = index.AddObject(map[string]interface{}{"f": "f1", "g": "g1"})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.AddObject(map[string]interface{}{"f": "f1", "g": "g2"})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.AddObject(map[string]interface{}{"f": "f2", "g": "g2"})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	task, err := index.AddObject(map[string]interface{}{"f": "f3", "g": "g2"})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_, err = index.WaitTask(task)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 
-  
-  index.Delete()
+	res, err := index.Search("", map[string]interface{}{"facets": "f", "facetFilters": []string{"f:f1"}})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	shouldFloat(res, "nbHits", 2, "Unable to filter facets", t)
+
+	index.Delete()
 }

--- a/algoliasearch/Index.go
+++ b/algoliasearch/Index.go
@@ -1,291 +1,291 @@
 package algoliasearch
 
 import (
-"time"
-"strconv"
-"net/url"
-"errors"
-"reflect"
+	"errors"
+	"net/url"
+	"reflect"
+	"strconv"
+	"time"
 )
 
 type Index struct {
-  name string
-  nameEncoded string
-  client *Client
+	name        string
+	nameEncoded string
+	client      *Client
 }
 
 func NewIndex(name string, client *Client) *Index {
-  index := new(Index)
-  index.name = name
-  index.client = client
-  index.nameEncoded = client.transport.urlEncode(name)
-  return index
+	index := new(Index)
+	index.name = name
+	index.client = client
+	index.nameEncoded = client.transport.urlEncode(name)
+	return index
 }
 
 func (i *Index) Delete() (interface{}, error) {
-  return i.client.transport.request("DELETE", "/1/indexes/" + i.nameEncoded, nil, write)
+	return i.client.transport.request("DELETE", "/1/indexes/"+i.nameEncoded, nil, write)
 }
 
 func (i *Index) Clear() (interface{}, error) {
-  return i.client.transport.request("POST", "/1/indexes/" + i.nameEncoded + "/clear", nil, write)
+	return i.client.transport.request("POST", "/1/indexes/"+i.nameEncoded+"/clear", nil, write)
 }
 
 func (i *Index) GetObject(objectID string, attribute ...string) (interface{}, error) {
-  v := url.Values{}
-  if len(attribute) > 1 {
-    return nil, errors.New("Too many parametter")
-  }
-  if len(attribute) > 0 {
-    v.Add("attribute", attribute[0])
-  }
-  return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/" + i.client.transport.urlEncode(objectID) + "?" + v.Encode(), nil, read)
+	v := url.Values{}
+	if len(attribute) > 1 {
+		return nil, errors.New("Too many parametter")
+	}
+	if len(attribute) > 0 {
+		v.Add("attribute", attribute[0])
+	}
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/"+i.client.transport.urlEncode(objectID)+"?"+v.Encode(), nil, read)
 }
 
 func (i *Index) GetObjects(objectIDs ...string) (interface{}, error) {
-  requests := make([]interface{}, len(objectIDs))
-  for it := range objectIDs {
-    object := make(map[string]interface{})
-    object["indexName"] = i.name
-    object["objectID"] = objectIDs[it]
-    requests[it] = object
-  }
-  body := make(map[string]interface{})
-  body["requests"] = requests
-  return i.client.transport.request("POST", "/1/indexes/*/objects", body, read);
+	requests := make([]interface{}, len(objectIDs))
+	for it := range objectIDs {
+		object := make(map[string]interface{})
+		object["indexName"] = i.name
+		object["objectID"] = objectIDs[it]
+		requests[it] = object
+	}
+	body := make(map[string]interface{})
+	body["requests"] = requests
+	return i.client.transport.request("POST", "/1/indexes/*/objects", body, read)
 }
 
 func (i *Index) DeleteObject(objectID string) (interface{}, error) {
-  return i.client.transport.request("DELETE", "/1/indexes/" + i.nameEncoded + "/" +  i.client.transport.urlEncode(objectID), nil, write)
+	return i.client.transport.request("DELETE", "/1/indexes/"+i.nameEncoded+"/"+i.client.transport.urlEncode(objectID), nil, write)
 }
 
 func (i *Index) GetSettings() (interface{}, error) {
-  return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/settings", nil, read)
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/settings", nil, read)
 }
 
 func (i *Index) SetSettings(settings interface{}) (interface{}, error) {
-  return i.client.transport.request("PUT", "/1/indexes/" + i.nameEncoded + "/settings", settings, write)
+	return i.client.transport.request("PUT", "/1/indexes/"+i.nameEncoded+"/settings", settings, write)
 }
 
 func (i *Index) getStatus(taskID float64) (interface{}, error) {
-  return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/task/" + strconv.FormatFloat(taskID, 'f', -1, 64), nil, read)
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/task/"+strconv.FormatFloat(taskID, 'f', -1, 64), nil, read)
 }
 
 func (i *Index) WaitTask(task interface{}) (interface{}, error) {
-  if reflect.TypeOf(task).Name() == "float64" {
-    return  i.WaitTaskWithInit(task.(float64), 100)
-  }
-  return  i.WaitTaskWithInit(task.(map[string]interface{})["taskID"].(float64), 100)
+	if reflect.TypeOf(task).Name() == "float64" {
+		return i.WaitTaskWithInit(task.(float64), 100)
+	}
+	return i.WaitTaskWithInit(task.(map[string]interface{})["taskID"].(float64), 100)
 }
 
 func (i *Index) WaitTaskWithInit(taskID float64, timeToWait float64) (interface{}, error) {
-  for true {
-    status, err := i.getStatus(taskID)
-    if err != nil {
-      return nil, err
-    }
-    if status.(map[string]interface{})["status"] == "published" {
-      return status, nil
-    }
-    time.Sleep(time.Duration(timeToWait) * time.Millisecond)
-    timeToWait = timeToWait * 2;
-    if (timeToWait > 10000) {
-      timeToWait = 10000
-    }
-  }
-  return nil, errors.New("Code not reachable")
+	for true {
+		status, err := i.getStatus(taskID)
+		if err != nil {
+			return nil, err
+		}
+		if status.(map[string]interface{})["status"] == "published" {
+			return status, nil
+		}
+		time.Sleep(time.Duration(timeToWait) * time.Millisecond)
+		timeToWait = timeToWait * 2
+		if timeToWait > 10000 {
+			timeToWait = 10000
+		}
+	}
+	return nil, errors.New("Code not reachable")
 }
 
 func (i *Index) ListKeys() (interface{}, error) {
-  return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/keys", nil, read)
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/keys", nil, read)
 }
 
 func (i *Index) GetKey(key string) (interface{}, error) {
-  return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/keys/" + key , nil, read)
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/keys/"+key, nil, read)
 }
 
 func (i *Index) DeleteKey(key string) (interface{}, error) {
-  return i.client.transport.request("DELETE", "/1/indexes/" + i.nameEncoded + "/keys/" + key , nil, write)
+	return i.client.transport.request("DELETE", "/1/indexes/"+i.nameEncoded+"/keys/"+key, nil, write)
 }
 
 func (i *Index) AddObject(object interface{}) (interface{}, error) {
-  method := "POST"
-  path := "/1/indexes/" + i.nameEncoded
-  if id, ok := object.(map[string]interface{})["objectID"]; ok {
-    method = "PUT"
-    path = path + "/" + i.client.transport.urlEncode(id.(string))
-  }
-  return i.client.transport.request(method, path, object, write)
+	method := "POST"
+	path := "/1/indexes/" + i.nameEncoded
+	if id, ok := object.(map[string]interface{})["objectID"]; ok {
+		method = "PUT"
+		path = path + "/" + i.client.transport.urlEncode(id.(string))
+	}
+	return i.client.transport.request(method, path, object, write)
 }
 
 func (i *Index) UpdateObject(object interface{}) (interface{}, error) {
-  id := object.(map[string]interface{})["objectID"]
-  path := "/1/indexes/" + i.nameEncoded + "/" + i.client.transport.urlEncode(id.(string))
-  return i.client.transport.request("PUT", path, object, write)
+	id := object.(map[string]interface{})["objectID"]
+	path := "/1/indexes/" + i.nameEncoded + "/" + i.client.transport.urlEncode(id.(string))
+	return i.client.transport.request("PUT", path, object, write)
 }
 
 func (i *Index) PartialUpdateObject(object interface{}) (interface{}, error) {
-  id := object.(map[string]interface{})["objectID"]
-  path := "/1/indexes/" + i.nameEncoded + "/" + i.client.transport.urlEncode(id.(string)) + "/partial"
-  return i.client.transport.request("POST", path, object, write)
+	id := object.(map[string]interface{})["objectID"]
+	path := "/1/indexes/" + i.nameEncoded + "/" + i.client.transport.urlEncode(id.(string)) + "/partial"
+	return i.client.transport.request("POST", path, object, write)
 }
 
 func (i *Index) AddObjects(objects interface{}) (interface{}, error) {
-  return i.sameBatch(objects, "addObject")
+	return i.sameBatch(objects, "addObject")
 }
 
 func (i *Index) UpdateObjects(objects interface{}) (interface{}, error) {
-  return i.sameBatch(objects, "updateObject")
+	return i.sameBatch(objects, "updateObject")
 }
 
 func (i *Index) PartialUpdateObjects(objects interface{}) (interface{}, error) {
-  return i.sameBatch(objects, "partialUpdateObject")
+	return i.sameBatch(objects, "partialUpdateObject")
 }
 
 func (i *Index) DeleteObjects(objectIDs []string) (interface{}, error) {
-  objects := make([]interface{}, len(objectIDs))
-  for i := range objectIDs {
-    object := make(map[string]interface{})
-    object["objectID"] = objectIDs[i]
-    objects[i] = object
-  }
-  return i.sameBatch(objects, "deleteObject")
+	objects := make([]interface{}, len(objectIDs))
+	for i := range objectIDs {
+		object := make(map[string]interface{})
+		object["objectID"] = objectIDs[i]
+		objects[i] = object
+	}
+	return i.sameBatch(objects, "deleteObject")
 }
 
 func (i *Index) DeleteByQuery(query string, params map[string]interface{}) (interface{}, error) {
-  if (params == nil) {
-    params = make(map[string]interface{})
-  }
-  params["attributesToRetrieve"] = "[\"objectID\"]"
-  params["hitsPerPage"] = 1000
+	if params == nil {
+		params = make(map[string]interface{})
+	}
+	params["attributesToRetrieve"] = "[\"objectID\"]"
+	params["hitsPerPage"] = 1000
 
-  results, error := i.Search(query, params)
-  if error != nil {
-    return results, error
-  }
-  for results.(map[string]interface{})["nbHits"].(float64) != 0 {
-    objectIDs := make([]string, len(results.(map[string]interface{})["hits"].([]interface{})))
-    for i := range results.(map[string]interface{})["hits"].([]interface{}) {
-      hits := results.(map[string]interface{})["hits"].([]interface{})[i].(map[string]interface{})
-      objectIDs[i] = hits["objectID"].(string)
-    }
-    task, error := i.DeleteObjects(objectIDs)
-    if error != nil {
-      return task, error
-    }
-     
-    _, error = i.WaitTask(task)
-    if error != nil {
-      return nil, error
-    }
-    results, error = i.Search(query, params)
-    if error != nil {
-      return results, error
-    }
-  }
-  return nil, nil
+	results, error := i.Search(query, params)
+	if error != nil {
+		return results, error
+	}
+	for results.(map[string]interface{})["nbHits"].(float64) != 0 {
+		objectIDs := make([]string, len(results.(map[string]interface{})["hits"].([]interface{})))
+		for i := range results.(map[string]interface{})["hits"].([]interface{}) {
+			hits := results.(map[string]interface{})["hits"].([]interface{})[i].(map[string]interface{})
+			objectIDs[i] = hits["objectID"].(string)
+		}
+		task, error := i.DeleteObjects(objectIDs)
+		if error != nil {
+			return task, error
+		}
+
+		_, error = i.WaitTask(task)
+		if error != nil {
+			return nil, error
+		}
+		results, error = i.Search(query, params)
+		if error != nil {
+			return results, error
+		}
+	}
+	return nil, nil
 }
 
 func (i *Index) sameBatch(objects interface{}, action string) (interface{}, error) {
-  length := len(objects.([]interface{}))
-  method := make([]string, length)
-  for i := range method {
-    method[i] = action
-  }
-  return i.Batch(objects, method)
+	length := len(objects.([]interface{}))
+	method := make([]string, length)
+	for i := range method {
+		method[i] = action
+	}
+	return i.Batch(objects, method)
 }
 
 func (i *Index) Batch(objects interface{}, actions []string) (interface{}, error) {
-  array := objects.([]interface{})
-  queries := make([]map[string]interface{}, len(array))
-  for i := range array {
-    queries[i] = make(map[string]interface{})
-    queries[i]["action"] = actions[i]
-    queries[i]["body"] = array[i]
-  }
-  return i.CustomBatch(queries)
+	array := objects.([]interface{})
+	queries := make([]map[string]interface{}, len(array))
+	for i := range array {
+		queries[i] = make(map[string]interface{})
+		queries[i]["action"] = actions[i]
+		queries[i]["body"] = array[i]
+	}
+	return i.CustomBatch(queries)
 }
 
 func (i *Index) CustomBatch(queries interface{}) (interface{}, error) {
-  request :=  make(map[string]interface{})
-  request["requests"] = queries
-  return i.client.transport.request("POST", "/1/indexes/" + i.nameEncoded + "/batch", request, write)
+	request := make(map[string]interface{})
+	request["requests"] = queries
+	return i.client.transport.request("POST", "/1/indexes/"+i.nameEncoded+"/batch", request, write)
 }
 
 // Deprecated use BrowseFrom or BrowseAll
 func (i *Index) Browse(page, hitsPerPage int) (interface{}, error) {
-  return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/browse?page=" + strconv.Itoa(page) + "&hitsPerPage=" + strconv.Itoa(hitsPerPage) , nil, read)
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/browse?page="+strconv.Itoa(page)+"&hitsPerPage="+strconv.Itoa(hitsPerPage), nil, read)
 }
 
 func (i *Index) makeIndexIterator(params interface{}, cursor string) (*IndexIterator, error) {
-  it := new(IndexIterator)
-  it.answer = map[string]interface{} {"cursor": cursor}
-  it.params = params
-  it.pos = 0
-  it.index = i
-  ok := it.loadNextPage()
-  return it, ok
+	it := new(IndexIterator)
+	it.answer = map[string]interface{}{"cursor": cursor}
+	it.params = params
+	it.pos = 0
+	it.index = i
+	ok := it.loadNextPage()
+	return it, ok
 }
 
 func (i *Index) BrowseFrom(params interface{}, cursor string) (interface{}, error) {
-  if (len(cursor) != 0) {
-    cursor = "&cursor=" + cursor
-  } else {
-    cursor = ""
-  }
- return i.client.transport.request("GET", "/1/indexes/" + i.nameEncoded + "/browse?" + i.client.transport.EncodeParams(params) + cursor, nil, read)
+	if len(cursor) != 0 {
+		cursor = "&cursor=" + cursor
+	} else {
+		cursor = ""
+	}
+	return i.client.transport.request("GET", "/1/indexes/"+i.nameEncoded+"/browse?"+i.client.transport.EncodeParams(params)+cursor, nil, read)
 }
 
 func (i *Index) BrowseAll(params interface{}) (*IndexIterator, error) {
- return i.makeIndexIterator(params, "")
+	return i.makeIndexIterator(params, "")
 }
 
 func (i *Index) Search(query string, params interface{}) (interface{}, error) {
-  if params == nil {
-    params = make(map[string]interface{})
-  }
-  params.(map[string]interface{})["query"] = query
-  body := make(map[string]interface{})
-  body["params"] = i.client.transport.EncodeParams(params)
-  return i.client.transport.request("POST", "/1/indexes/" + i.nameEncoded + "/query", body, search)
+	if params == nil {
+		params = make(map[string]interface{})
+	}
+	params.(map[string]interface{})["query"] = query
+	body := make(map[string]interface{})
+	body["params"] = i.client.transport.EncodeParams(params)
+	return i.client.transport.request("POST", "/1/indexes/"+i.nameEncoded+"/query", body, search)
 }
 
 func (i *Index) operation(name, op string) (interface{}, error) {
-  body := make(map[string]interface{})
-  body["operation"] = op
-  body["destination"] = name
-  return i.client.transport.request("POST", "/1/indexes/" + i.nameEncoded + "/operation", body, write)
+	body := make(map[string]interface{})
+	body["operation"] = op
+	body["destination"] = name
+	return i.client.transport.request("POST", "/1/indexes/"+i.nameEncoded+"/operation", body, write)
 }
 
 func (i *Index) Copy(name string) (interface{}, error) {
-  return i.operation(name, "copy")
+	return i.operation(name, "copy")
 }
 
 func (i *Index) Move(name string) (interface{}, error) {
-  return i.operation(name, "move")
+	return i.operation(name, "move")
 }
 
 func (i *Index) AddKey(acl []string, validity int, maxQueriesPerIPPerHour int, maxHitsPerQuery int) (interface{}, error) {
-  body := make(map[string]interface{})
-  body["acl"] = acl
-  body["maxHitsPerQuery"] = maxHitsPerQuery
-  body["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour
-  body["validity"] = validity
-  return i.AddKeyWithParam(body)
+	body := make(map[string]interface{})
+	body["acl"] = acl
+	body["maxHitsPerQuery"] = maxHitsPerQuery
+	body["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour
+	body["validity"] = validity
+	return i.AddKeyWithParam(body)
 }
 
 func (i *Index) AddKeyWithParam(params interface{}) (interface{}, error) {
-  return i.client.transport.request("POST", "/1/indexes/" + i.nameEncoded + "/keys", params, write)
+	return i.client.transport.request("POST", "/1/indexes/"+i.nameEncoded+"/keys", params, write)
 }
 
 func (i *Index) UpdateKey(key string, acl []string, validity int, maxQueriesPerIPPerHour int, maxHitsPerQuery int) (interface{}, error) {
-  body := make(map[string]interface{})
-  body["acl"] = acl
-  body["maxHitsPerQuery"] = maxHitsPerQuery
-  body["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour
-  body["validity"] = validity
-  return i.UpdateKeyWithParam(key, body)
+	body := make(map[string]interface{})
+	body["acl"] = acl
+	body["maxHitsPerQuery"] = maxHitsPerQuery
+	body["maxQueriesPerIPPerHour"] = maxQueriesPerIPPerHour
+	body["validity"] = validity
+	return i.UpdateKeyWithParam(key, body)
 }
 
 func (i *Index) UpdateKeyWithParam(key string, params interface{}) (interface{}, error) {
-  return i.client.transport.request("PUT", "/1/indexes/" + i.nameEncoded + "/keys/" + key, params, write)
+	return i.client.transport.request("PUT", "/1/indexes/"+i.nameEncoded+"/keys/"+key, params, write)
 }

--- a/algoliasearch/IndexIterator.go
+++ b/algoliasearch/IndexIterator.go
@@ -5,19 +5,19 @@ import (
 )
 
 type IndexIterator struct {
-  answer interface{}
-  params interface{}
-  pos int
-  index *Index
+	answer interface{}
+	params interface{}
+	pos    int
+	index  *Index
 }
 
 func (it *IndexIterator) Next() (interface{}, error) {
 	var err error
-	for (err == nil) {
+	for err == nil {
 		hits := it.answer.(map[string]interface{})["hits"].([]interface{})
 		if it.pos < len(hits) {
 			it.pos++
-			return hits[it.pos - 1], nil
+			return hits[it.pos-1], nil
 		}
 		if cursor, ok := it.GetCursor(); ok && len(cursor) > 0 {
 			err = it.loadNextPage()
@@ -31,13 +31,13 @@ func (it *IndexIterator) Next() (interface{}, error) {
 func (it *IndexIterator) GetCursor() (string, bool) {
 	cursor, ok := it.answer.(map[string]interface{})["cursor"]
 	cursorStr := ""
-	if (cursor != nil) {
+	if cursor != nil {
 		cursorStr = cursor.(string)
 	}
 	return cursorStr, ok
 }
 
-func (it *IndexIterator) loadNextPage() (error) {
+func (it *IndexIterator) loadNextPage() error {
 	it.pos = 0
 	cursor, _ := it.GetCursor()
 	answer, err := it.index.BrowseFrom(it.params, cursor)

--- a/algoliasearch/SearchResult.go
+++ b/algoliasearch/SearchResult.go
@@ -1,0 +1,14 @@
+package algoliasearch
+
+type SearchResult struct {
+	Hits             []map[string]interface{}
+	Page             int
+	NbHits           int
+	NbPages          int
+	HitsPerPage      int
+	ProcessingTimeMS int
+	Facets           map[string]interface{}
+	FacetStats       map[string]interface{} `json:"facet_stats"`
+	Query            string
+	Params           string
+}

--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -11,207 +11,208 @@ import "time"
 import "reflect"
 import "strings"
 import "fmt"
+
 // Fix certificates
 import _ "crypto/sha512"
 
 const (
-  version = "1.2.1"
+	version = "1.2.1"
 )
 
 const (
-  search = 1 << iota
-  write
-  read
+	search = 1 << iota
+	write
+	read
 )
 
 type Transport struct {
-  httpClient *http.Client
-  appID string
-  apiKey string
-  headers map[string]string
-  hosts []string
-  hostsProvided bool
-  connectTimeout time.Duration
-  buildReadTimeout time.Duration
-  searchReadTimeout time.Duration
+	httpClient        *http.Client
+	appID             string
+	apiKey            string
+	headers           map[string]string
+	hosts             []string
+	hostsProvided     bool
+	connectTimeout    time.Duration
+	buildReadTimeout  time.Duration
+	searchReadTimeout time.Duration
 }
 
 func NewTransport(appID, apiKey string) *Transport {
-  transport := new(Transport)
-  transport.appID = appID
-  transport.apiKey = apiKey
-  tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
-  transport.httpClient = &http.Client{Transport: tr}
-  transport.headers = make(map[string]string)
-  //transport.hosts = [3]string{"https://" + appID + suffix[perm[0]], "https://" + appID + suffix[perm[1]], "https://" + appID + suffix[perm[2]], }
-  transport.hosts = make([]string, 3)
-  transport.hosts[0] = appID + "-1.algolianet.com"
-  transport.hosts[1] = appID + "-2.algolianet.com"
-  transport.hosts[2] = appID + "-3.algolianet.com"
-  transport.hostsProvided = false
-  transport.connectTimeout = 1 * time.Second
-  transport.buildReadTimeout = 30 * time.Second
-  transport.searchReadTimeout = 5 * time.Second
-  return transport
+	transport := new(Transport)
+	transport.appID = appID
+	transport.apiKey = apiKey
+	tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
+	transport.httpClient = &http.Client{Transport: tr}
+	transport.headers = make(map[string]string)
+	//transport.hosts = [3]string{"https://" + appID + suffix[perm[0]], "https://" + appID + suffix[perm[1]], "https://" + appID + suffix[perm[2]], }
+	transport.hosts = make([]string, 3)
+	transport.hosts[0] = appID + "-1.algolianet.com"
+	transport.hosts[1] = appID + "-2.algolianet.com"
+	transport.hosts[2] = appID + "-3.algolianet.com"
+	transport.hostsProvided = false
+	transport.connectTimeout = 1 * time.Second
+	transport.buildReadTimeout = 30 * time.Second
+	transport.searchReadTimeout = 5 * time.Second
+	return transport
 }
 
 func NewTransportWithHosts(appID, apiKey string, hosts []string) *Transport {
-  transport := new(Transport)
-  transport.appID = appID
-  transport.apiKey = apiKey
-  tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
-  transport.httpClient = &http.Client{Transport: tr}
-  transport.headers = make(map[string]string)
-  transport.hosts = hosts
-  transport.hostsProvided = true
-  transport.connectTimeout = 2 * time.Second
-  transport.buildReadTimeout = 30 * time.Second
-  transport.searchReadTimeout = 5 * time.Second
-  return transport
+	transport := new(Transport)
+	transport.appID = appID
+	transport.apiKey = apiKey
+	tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
+	transport.httpClient = &http.Client{Transport: tr}
+	transport.headers = make(map[string]string)
+	transport.hosts = hosts
+	transport.hostsProvided = true
+	transport.connectTimeout = 2 * time.Second
+	transport.buildReadTimeout = 30 * time.Second
+	transport.searchReadTimeout = 5 * time.Second
+	return transport
 }
 
 func (t *Transport) setTimeout(connectTimeout time.Duration, readTimeout time.Duration) {
-  t.connectTimeout = connectTimeout
-  t.buildReadTimeout = readTimeout
+	t.connectTimeout = connectTimeout
+	t.buildReadTimeout = readTimeout
 }
 
 func (t *Transport) setSearchTimeout(searchTimeout time.Duration) {
-  t.searchReadTimeout = searchTimeout
+	t.searchReadTimeout = searchTimeout
 }
 
 func (t *Transport) urlEncode(value string) string {
-  return url.QueryEscape(value)
+	return url.QueryEscape(value)
 }
 
 func (t *Transport) setExtraHeader(key string, value string) {
-  t.headers[key] = value
+	t.headers[key] = value
 }
 
 func (t *Transport) EncodeParams(params interface{}) string {
-  v := url.Values{}
-  if params != nil {
-    for key, value := range params.(map[string]interface{}) {
-      if reflect.TypeOf(value).Name() == "string" {
-        v.Add(key, value.(string))
-      } else if reflect.TypeOf(value).Name() == "float64" {
-        v.Add(key, strconv.FormatFloat(value.(float64), 'f', -1, 64))
-      } else if reflect.TypeOf(value).Name() == "int" {
-        v.Add(key, strconv.Itoa(value.(int)))
-      } else {
-        jsonValue, _ := json.Marshal(value)
-        v.Add(key, string(jsonValue[:]))
-      }
-    }
-  }
-  return v.Encode()
+	v := url.Values{}
+	if params != nil {
+		for key, value := range params.(map[string]interface{}) {
+			if reflect.TypeOf(value).Name() == "string" {
+				v.Add(key, value.(string))
+			} else if reflect.TypeOf(value).Name() == "float64" {
+				v.Add(key, strconv.FormatFloat(value.(float64), 'f', -1, 64))
+			} else if reflect.TypeOf(value).Name() == "int" {
+				v.Add(key, strconv.Itoa(value.(int)))
+			} else {
+				jsonValue, _ := json.Marshal(value)
+				v.Add(key, string(jsonValue[:]))
+			}
+		}
+	}
+	return v.Encode()
 }
 
 func (t *Transport) request(method, path string, body interface{}, typeCall int) (interface{}, error) {
-  var host string
-  errorMsg := ""
-  t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout = t.connectTimeout
-  if typeCall == write  {
-    host = t.appID + ".algolia.net"
-    t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.searchReadTimeout
-  } else {
-    host = t.appID + "-dsn.algolia.net"
-    if (typeCall == read) {
-      t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.buildReadTimeout
-    } else {
-      t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.searchReadTimeout
-    }
-  }
-  if ! t.hostsProvided {
-    req, err := t.buildRequest(method, host, path, body)
-    if err != nil {
-      return nil, err
-    }
-    req = t.addHeaders(req)
-    resp, err := t.httpClient.Do(req)
-    if err != nil {
-      if len(errorMsg) > 0 {
-        errorMsg = fmt.Sprintf("%s, %s:%s", errorMsg, host, err)
-      } else {
-        errorMsg = fmt.Sprintf("%s:%s", host, err)
-      }
-    } else if (resp.StatusCode / 100) == 2 || (resp.StatusCode / 100) == 4 { // Bad request, not found, forbidden
-      return t.handleResponse(resp)
-    }
-  }
-  for it := range t.hosts {
-    req, err := t.buildRequest(method, t.hosts[it], path, body)
-    if err != nil {
-      return nil, err
-    }
-    req = t.addHeaders(req)
-    resp, err := t.httpClient.Do(req)
-    if err != nil {
-      if len(errorMsg) > 0 {
-        errorMsg = fmt.Sprintf("%s, %s:%s", errorMsg, t.hosts[it], err)
-      } else {
-        errorMsg = fmt.Sprintf("%s:%s", t.hosts[it], err)
-      }
-      continue
-    }
-    if (resp.StatusCode / 100) == 2 || (resp.StatusCode / 100) == 4 { // Bad request, not found, forbidden
-      return t.handleResponse(resp)
-    }
-  }
-  return nil, errors.New(fmt.Sprintf("Cannot reach any host. (%s)", errorMsg))
+	var host string
+	errorMsg := ""
+	t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout = t.connectTimeout
+	if typeCall == write {
+		host = t.appID + ".algolia.net"
+		t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.searchReadTimeout
+	} else {
+		host = t.appID + "-dsn.algolia.net"
+		if typeCall == read {
+			t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.buildReadTimeout
+		} else {
+			t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.searchReadTimeout
+		}
+	}
+	if !t.hostsProvided {
+		req, err := t.buildRequest(method, host, path, body)
+		if err != nil {
+			return nil, err
+		}
+		req = t.addHeaders(req)
+		resp, err := t.httpClient.Do(req)
+		if err != nil {
+			if len(errorMsg) > 0 {
+				errorMsg = fmt.Sprintf("%s, %s:%s", errorMsg, host, err)
+			} else {
+				errorMsg = fmt.Sprintf("%s:%s", host, err)
+			}
+		} else if (resp.StatusCode/100) == 2 || (resp.StatusCode/100) == 4 { // Bad request, not found, forbidden
+			return t.handleResponse(resp)
+		}
+	}
+	for it := range t.hosts {
+		req, err := t.buildRequest(method, t.hosts[it], path, body)
+		if err != nil {
+			return nil, err
+		}
+		req = t.addHeaders(req)
+		resp, err := t.httpClient.Do(req)
+		if err != nil {
+			if len(errorMsg) > 0 {
+				errorMsg = fmt.Sprintf("%s, %s:%s", errorMsg, t.hosts[it], err)
+			} else {
+				errorMsg = fmt.Sprintf("%s:%s", t.hosts[it], err)
+			}
+			continue
+		}
+		if (resp.StatusCode/100) == 2 || (resp.StatusCode/100) == 4 { // Bad request, not found, forbidden
+			return t.handleResponse(resp)
+		}
+	}
+	return nil, errors.New(fmt.Sprintf("Cannot reach any host. (%s)", errorMsg))
 }
 
 func (t *Transport) buildRequest(method, host, path string, body interface{}) (*http.Request, error) {
-  var req *http.Request
-  var err error
-  if body != nil {
-    bodyBytes, err := json.Marshal(body)
-    if err != nil {
-      return nil, errors.New("Invalid JSON in the query")
-    }
-    reader := bytes.NewReader(bodyBytes)
-    req, err = http.NewRequest(method, "https://" + host + path, reader)
-    req.Header.Add("Content-Length", strconv.Itoa(len(string(bodyBytes))))
-    req.Header.Add("Content-Type", "application/json; charset=utf-8")
-  } else {
-    req, err = http.NewRequest(method, "https://" + host + path, nil)
-  }
-  if strings.Contains(path, "/*/") {
-    req.URL = &url.URL{
-       Scheme: "https",
-       Host: host,
-       Opaque: "//" + host + path, //Remove url encoding
-     }
-  }
-  t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout += 2 * time.Second
-  t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = 10 * time.Second
-  return req, err
+	var req *http.Request
+	var err error
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return nil, errors.New("Invalid JSON in the query")
+		}
+		reader := bytes.NewReader(bodyBytes)
+		req, err = http.NewRequest(method, "https://"+host+path, reader)
+		req.Header.Add("Content-Length", strconv.Itoa(len(string(bodyBytes))))
+		req.Header.Add("Content-Type", "application/json; charset=utf-8")
+	} else {
+		req, err = http.NewRequest(method, "https://"+host+path, nil)
+	}
+	if strings.Contains(path, "/*/") {
+		req.URL = &url.URL{
+			Scheme: "https",
+			Host:   host,
+			Opaque: "//" + host + path, //Remove url encoding
+		}
+	}
+	t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout += 2 * time.Second
+	t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = 10 * time.Second
+	return req, err
 }
 
 func (t *Transport) addHeaders(req *http.Request) *http.Request {
-  req.Header.Add("X-Algolia-API-Key", t.apiKey)
-  req.Header.Add("X-Algolia-Application-Id", t.appID)
-  req.Header.Add("Connection", "keep-alive")
-  req.Header.Add("User-Agent", "Algolia for go " + version)
-  for key := range t.headers {
-    req.Header.Add(key, t.headers[key])
-  }
-  return req
+	req.Header.Add("X-Algolia-API-Key", t.apiKey)
+	req.Header.Add("X-Algolia-Application-Id", t.appID)
+	req.Header.Add("Connection", "keep-alive")
+	req.Header.Add("User-Agent", "Algolia for go "+version)
+	for key := range t.headers {
+		req.Header.Add(key, t.headers[key])
+	}
+	return req
 }
 
 func (t *Transport) handleResponse(resp *http.Response) (interface{}, error) {
-  res, err := ioutil.ReadAll(resp.Body)
-  resp.Body.Close()
-  if err != nil {
-    return nil, err
-  }
-  var jsonResp interface{}
-  err = json.Unmarshal(res, &jsonResp)
-  if err != nil {
-    return nil, errors.New("Invalid JSON in the response")
-  }
-  if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-    return jsonResp, nil
-  } else {
-    return nil, errors.New(string(res))
-  }
+	res, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	var jsonResp interface{}
+	err = json.Unmarshal(res, &jsonResp)
+	if err != nil {
+		return nil, errors.New("Invalid JSON in the response")
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return jsonResp, nil
+	} else {
+		return nil, errors.New(string(res))
+	}
 }

--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -205,13 +205,13 @@ func (t *Transport) handleResponse(resp *http.Response) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var jsonResp interface{}
-	err = json.Unmarshal(res, &jsonResp)
+	var result SearchResult
+	err = json.Unmarshal(res, &result)
 	if err != nil {
 		return nil, errors.New("Invalid JSON in the response")
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return jsonResp, nil
+		return result, nil
 	} else {
 		return nil, errors.New(string(res))
 	}


### PR DESCRIPTION
This creates a struct for a `SearchResult` so we don't have to keep doing the parsing into `map[string]interface{}` or just `interface{}`, which should be avoided anyways. 

It really cleans up the search code!

See: https://github.com/usecanvas/canvas-cli/commit/f335b461f5739710ab6c721231b004ed5e9ba2c9