### PR TITLE
simplify transport. should close response bodies.

### DIFF
--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -41,7 +41,7 @@ func NewTransport(appID, apiKey string) *Transport {
 	tr := &http.Transport{
 		DisableKeepAlives:     false,
 		MaxIdleConnsPerHost:   2,
-		TLSHandshakeTimeout:   time.Second,
+		TLSHandshakeTimeout:   time.Second * 2,
 		ResponseHeaderTimeout: time.Second * 10}
 
 	transport.httpClient = &http.Client{Transport: tr}
@@ -61,7 +61,7 @@ func NewTransportWithHosts(appID, apiKey string, hosts []string) *Transport {
 	tr := &http.Transport{
 		DisableKeepAlives:     false,
 		MaxIdleConnsPerHost:   2,
-		TLSHandshakeTimeout:   time.Second,
+		TLSHandshakeTimeout:   time.Second * 2,
 		ResponseHeaderTimeout: time.Second * 10}
 
 	transport.httpClient = &http.Client{Transport: tr}
@@ -178,8 +178,6 @@ func (t *Transport) buildRequest(method, host, path string, body interface{}) (*
 			Opaque: "//" + host + path, //Remove url encoding
 		}
 	}
-	t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout += 2 * time.Second
-	t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = 10 * time.Second
 	return req, err
 }
 

--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -26,33 +26,31 @@ const (
 )
 
 type Transport struct {
-	httpClient        *http.Client
-	appID             string
-	apiKey            string
-	headers           map[string]string
-	hosts             []string
-	hostsProvided     bool
-	connectTimeout    time.Duration
-	buildReadTimeout  time.Duration
-	searchReadTimeout time.Duration
+	httpClient    *http.Client
+	appID         string
+	apiKey        string
+	headers       map[string]string
+	hosts         []string
+	hostsProvided bool
 }
 
 func NewTransport(appID, apiKey string) *Transport {
 	transport := new(Transport)
 	transport.appID = appID
 	transport.apiKey = apiKey
-	tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
+	tr := &http.Transport{
+		DisableKeepAlives:     false,
+		MaxIdleConnsPerHost:   2,
+		TLSHandshakeTimeout:   time.Second,
+		ResponseHeaderTimeout: time.Second * 10}
+
 	transport.httpClient = &http.Client{Transport: tr}
 	transport.headers = make(map[string]string)
-	//transport.hosts = [3]string{"https://" + appID + suffix[perm[0]], "https://" + appID + suffix[perm[1]], "https://" + appID + suffix[perm[2]], }
 	transport.hosts = make([]string, 3)
 	transport.hosts[0] = appID + "-1.algolianet.com"
 	transport.hosts[1] = appID + "-2.algolianet.com"
 	transport.hosts[2] = appID + "-3.algolianet.com"
 	transport.hostsProvided = false
-	transport.connectTimeout = 1 * time.Second
-	transport.buildReadTimeout = 30 * time.Second
-	transport.searchReadTimeout = 5 * time.Second
 	return transport
 }
 
@@ -60,24 +58,22 @@ func NewTransportWithHosts(appID, apiKey string, hosts []string) *Transport {
 	transport := new(Transport)
 	transport.appID = appID
 	transport.apiKey = apiKey
-	tr := &http.Transport{DisableKeepAlives: false, MaxIdleConnsPerHost: 2}
+	tr := &http.Transport{
+		DisableKeepAlives:     false,
+		MaxIdleConnsPerHost:   2,
+		TLSHandshakeTimeout:   time.Second,
+		ResponseHeaderTimeout: time.Second * 10}
+
 	transport.httpClient = &http.Client{Transport: tr}
 	transport.headers = make(map[string]string)
 	transport.hosts = hosts
 	transport.hostsProvided = true
-	transport.connectTimeout = 2 * time.Second
-	transport.buildReadTimeout = 30 * time.Second
-	transport.searchReadTimeout = 5 * time.Second
 	return transport
 }
 
 func (t *Transport) setTimeout(connectTimeout time.Duration, readTimeout time.Duration) {
-	t.connectTimeout = connectTimeout
-	t.buildReadTimeout = readTimeout
-}
-
-func (t *Transport) setSearchTimeout(searchTimeout time.Duration) {
-	t.searchReadTimeout = searchTimeout
+	t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout = connectTimeout
+	t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = readTimeout
 }
 
 func (t *Transport) urlEncode(value string) string {
@@ -110,18 +106,12 @@ func (t *Transport) EncodeParams(params interface{}) string {
 func (t *Transport) request(method, path string, body interface{}, typeCall int) (interface{}, error) {
 	var host string
 	errorMsg := ""
-	t.httpClient.Transport.(*http.Transport).TLSHandshakeTimeout = t.connectTimeout
 	if typeCall == write {
 		host = t.appID + ".algolia.net"
-		t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.searchReadTimeout
 	} else {
 		host = t.appID + "-dsn.algolia.net"
-		if typeCall == read {
-			t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.buildReadTimeout
-		} else {
-			t.httpClient.Transport.(*http.Transport).ResponseHeaderTimeout = t.searchReadTimeout
-		}
 	}
+
 	if !t.hostsProvided {
 		req, err := t.buildRequest(method, host, path, body)
 		if err != nil {
@@ -137,8 +127,11 @@ func (t *Transport) request(method, path string, body interface{}, typeCall int)
 			}
 		} else if (resp.StatusCode/100) == 2 || (resp.StatusCode/100) == 4 { // Bad request, not found, forbidden
 			return t.handleResponse(resp)
+		} else {
+			resp.Body.Close()
 		}
 	}
+
 	for it := range t.hosts {
 		req, err := t.buildRequest(method, t.hosts[it], path, body)
 		if err != nil {
@@ -156,6 +149,8 @@ func (t *Transport) request(method, path string, body interface{}, typeCall int)
 		}
 		if (resp.StatusCode/100) == 2 || (resp.StatusCode/100) == 4 { // Bad request, not found, forbidden
 			return t.handleResponse(resp)
+		} else {
+			resp.Body.Close()
 		}
 	}
 	return nil, errors.New(fmt.Sprintf("Cannot reach any host. (%s)", errorMsg))

--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -1,6 +1,9 @@
 package algoliasearch
 
-import "net/http"
+import (
+	"net"
+	"net/http"
+)
 import "net/url"
 import "io/ioutil"
 import "bytes"
@@ -39,12 +42,16 @@ func NewTransport(appID, apiKey string) *Transport {
 	transport.appID = appID
 	transport.apiKey = apiKey
 	tr := &http.Transport{
-		DisableKeepAlives:     false,
-		MaxIdleConnsPerHost:   2,
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: 2,
+		Dial: (&net.Dialer{
+			Timeout:   15 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
 		TLSHandshakeTimeout:   time.Second * 2,
 		ResponseHeaderTimeout: time.Second * 10}
 
-	transport.httpClient = &http.Client{Transport: tr}
+	transport.httpClient = &http.Client{Transport: tr, Timeout: time.Second * 15}
 	transport.headers = make(map[string]string)
 	transport.hosts = make([]string, 3)
 	transport.hosts[0] = appID + "-1.algolianet.com"
@@ -59,12 +66,16 @@ func NewTransportWithHosts(appID, apiKey string, hosts []string) *Transport {
 	transport.appID = appID
 	transport.apiKey = apiKey
 	tr := &http.Transport{
-		DisableKeepAlives:     false,
-		MaxIdleConnsPerHost:   2,
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: 2,
+		Dial: (&net.Dialer{
+			Timeout:   15 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
 		TLSHandshakeTimeout:   time.Second * 2,
 		ResponseHeaderTimeout: time.Second * 10}
 
-	transport.httpClient = &http.Client{Transport: tr}
+	transport.httpClient = &http.Client{Transport: tr, Timeout: time.Second * 15}
 	transport.headers = make(map[string]string)
 	transport.hosts = hosts
 	transport.hostsProvided = true


### PR DESCRIPTION
The transport is a shared resource that can be used from many threads. It doesn't make a lot of sense to be changing its values underneath inflight requests. If different timeout values are needed the client should hold onto multiple transports.

The client of http.Do is responsible for closing the resp body regardless of the http status. 