### PR TITLE
Update Quick Start section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ res, err := index.SetSettings(settings)
 
 Since the engine is designed to suggest results as you type, you'll generally search by prefix. In this case the order of attributes is very important to decide which hit is the best:
 ```go
-res, err := index.Query("or", nil)
-res, err = index.Query("jim", nil)
+res, err := index.Search("or", nil)
+res, err = index.Search("jim", nil)
 ```
 
 
@@ -384,7 +384,7 @@ You can use the following optional arguments:
   * **none**: If none of the query terms were found.
  * **attributesToSnippet**: A string that contains the list of attributes to snippet alongside the number of words to return (syntax is `attributeName:nbWords`). Attributes are separated by commas (Example: `attributesToSnippet=name:10,content:10`). <br/>You can also use a string array encoding (Example: `attributesToSnippet: ["name:10","content:10"]`). By default, no snippet is computed.
  * **getRankingInfo**: If set to 1, the result hits will contain ranking information in the **_rankingInfo** attribute.
- 
+
 
 #### Numeric Search Parameters
  * **numericFilters**: A string that contains the comma separated list of numeric filters you want to apply. The filter syntax is `attributeName` followed by `operand` followed by `value`. Supported operands are `<`, `<=`, `=`, `>` and `>=`.
@@ -955,7 +955,3 @@ res, err = client.GetLogs(0, 100, false)
 // Get last 100 log errors
 res, err = client.GetLogs(0, 100, true)
 ```
-
-
-
-


### PR DESCRIPTION
Seems as though this section of the Quick Start guide wasn't updated when the ```Query``` method was renamed to ```Search```.