### PR TITLE
Read Response's Body to completion before closing it

### DIFF
--- a/algoliasearch/Transport.go
+++ b/algoliasearch/Transport.go
@@ -1,6 +1,7 @@
 package algoliasearch
 
 import (
+	"io"
 	"net"
 	"net/http"
 )
@@ -139,6 +140,7 @@ func (t *Transport) request(method, path string, body interface{}, typeCall int)
 		} else if (resp.StatusCode/100) == 2 || (resp.StatusCode/100) == 4 { // Bad request, not found, forbidden
 			return t.handleResponse(resp)
 		} else {
+			io.Copy(ioutil.Discard, resp.Body)
 			resp.Body.Close()
 		}
 	}
@@ -161,6 +163,7 @@ func (t *Transport) request(method, path string, body interface{}, typeCall int)
 		if (resp.StatusCode/100) == 2 || (resp.StatusCode/100) == 4 { // Bad request, not found, forbidden
 			return t.handleResponse(resp)
 		} else {
+			io.Copy(ioutil.Discard, resp.Body)
 			resp.Body.Close()
 		}
 	}


### PR DESCRIPTION
The Response's Body wasn't read to completion before being closed. It led to
multiple retries from the default HTTP client. This commit fixes this issue by
actually reading the Body to completion.