### PR TITLE
Transport: refactor for httpClient creator + remove reflect

### DIFF
--- a/algoliasearch/Client.go
+++ b/algoliasearch/Client.go
@@ -3,12 +3,12 @@ package algoliasearch
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"reflect"
-	"time"
 	"strings"
-	"encoding/base64"
+	"time"
 )
 
 type Client struct {
@@ -117,8 +117,8 @@ func (c *Client) GenerateSecuredApiKey(apiKey string, public interface{}, userTo
 		}
 		message = c.transport.EncodeParams(public)
 	} else if strings.Contains(public.(string), "=") { // Url encoded query parameters
-		if (len(userTokenStr) != 0) {
-			message = public.(string) + "&" + c.transport.EncodeParams("userToken=" + c.transport.urlEncode(userTokenStr))
+		if len(userTokenStr) != 0 {
+			message = public.(string) + "&" + c.transport.EncodeParams("userToken="+c.transport.urlEncode(userTokenStr))
 		} else {
 			message = public.(string)
 		}

--- a/algoliasearch/Client_test.go
+++ b/algoliasearch/Client_test.go
@@ -781,19 +781,19 @@ func TestGenerateNewSecuredApiKey(t *testing.T) {
 	}
 	key, _ = client.GenerateSecuredApiKey("182634d8894831d5dbce3b3185c50881", map[string]interface{}{"tagFilters": "(public,user1)"})
 	expected = "MDZkNWNjNDY4M2MzMDA0NmUyNmNkZjY5OTMzYjVlNmVlMTk1NTEwMGNmNTVjZmJhMmIwOTIzYjdjMTk2NTFiMnRhZ0ZpbHRlcnM9JTI4cHVibGljJTJDdXNlcjElMjk="
-    if expected != key {
-    	t.Fatalf("Invalid key: " + key + " != " + expected)
-    }
-    key, _ = client.GenerateSecuredApiKey("182634d8894831d5dbce3b3185c50881", map[string]interface{}{"tagFilters": "(public,user1)", "userToken": "42"})
-    expected = "OGYwN2NlNTdlOGM2ZmM4MjA5NGM0ZmYwNTk3MDBkNzMzZjQ0MDI3MWZjNTNjM2Y3YTAzMWM4NTBkMzRiNTM5YnRhZ0ZpbHRlcnM9JTI4cHVibGljJTJDdXNlcjElMjkmdXNlclRva2VuPTQy"
-    if expected != key {
-    	t.Fatalf("Invalid key: " + key + " != " + expected)
-    }
-    key, _ = client.GenerateSecuredApiKey("182634d8894831d5dbce3b3185c50881", map[string]interface{}{"tagFilters": "(public,user1)"}, "42")
-    expected = "OGYwN2NlNTdlOGM2ZmM4MjA5NGM0ZmYwNTk3MDBkNzMzZjQ0MDI3MWZjNTNjM2Y3YTAzMWM4NTBkMzRiNTM5YnRhZ0ZpbHRlcnM9JTI4cHVibGljJTJDdXNlcjElMjkmdXNlclRva2VuPTQy"
-    if expected != key {
-    	t.Fatalf("Invalid key: " + key + " != " + expected)
-    }
+	if expected != key {
+		t.Fatalf("Invalid key: " + key + " != " + expected)
+	}
+	key, _ = client.GenerateSecuredApiKey("182634d8894831d5dbce3b3185c50881", map[string]interface{}{"tagFilters": "(public,user1)", "userToken": "42"})
+	expected = "OGYwN2NlNTdlOGM2ZmM4MjA5NGM0ZmYwNTk3MDBkNzMzZjQ0MDI3MWZjNTNjM2Y3YTAzMWM4NTBkMzRiNTM5YnRhZ0ZpbHRlcnM9JTI4cHVibGljJTJDdXNlcjElMjkmdXNlclRva2VuPTQy"
+	if expected != key {
+		t.Fatalf("Invalid key: " + key + " != " + expected)
+	}
+	key, _ = client.GenerateSecuredApiKey("182634d8894831d5dbce3b3185c50881", map[string]interface{}{"tagFilters": "(public,user1)"}, "42")
+	expected = "OGYwN2NlNTdlOGM2ZmM4MjA5NGM0ZmYwNTk3MDBkNzMzZjQ0MDI3MWZjNTNjM2Y3YTAzMWM4NTBkMzRiNTM5YnRhZ0ZpbHRlcnM9JTI4cHVibGljJTJDdXNlcjElMjkmdXNlclRva2VuPTQy"
+	if expected != key {
+		t.Fatalf("Invalid key: " + key + " != " + expected)
+	}
 }
 
 func TestMultipleQueries(t *testing.T) {


### PR DESCRIPTION
- Centralized code for creating a new http client.
- Removed reflect calls in favor of simpler plain type switches.
- Go fmt'd code in /algoliasearch.