### PR TITLE
Make GenerateSecuredAPIKey not part of Client

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -59,20 +59,6 @@ type Client interface {
 	// https://www.algolia.com/doc/rest#logs-api
 	GetLogs(params Map) (logs []LogRes, err error)
 
-	// GenerateSecuredAPIKey generates a public API key intended to restrict
-	// access to certain records. This new key is built upon the existing key
-	// named `apiKey` and the `params` map. The `params` map can contain any
-	// query parameters to restrict what needs to be and can also have the
-	// following fields:
-	//   - `userToken` (string identifier generally used to rate-limit users
-	//     per IP)
-	//   - `validUntil` (timestamp of the expiration date)
-	//   - `restrictIndices` (comma-separated string list of the indices to
-	//     restrict)
-	// More details here:
-	// https://www.algolia.com/doc/rest#request-from-browser-with-secure-restriction
-	GenerateSecuredAPIKey(apiKey string, params Map) (key string, err error)
-
 	// MultipleQueries performs all the queries specified in `queries` and
 	// aggregates the results. The `strategy` can either be set to `none`
 	// (default) which executes all the queries until the last one, or set to

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -1,10 +1,6 @@
 package algoliasearch
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"net/url"
 	"time"
@@ -122,21 +118,6 @@ func (c *client) GetLogs(params Map) (logs []LogRes, err error) {
 
 	err = c.request(&res, "GET", "/1/logs", params, write)
 	logs = res.Logs
-	return
-}
-
-func (c *client) GenerateSecuredAPIKey(apiKey string, params Map) (key string, err error) {
-	if err = checkGenerateSecuredAPIKey(params); err != nil {
-		return
-	}
-
-	message := encodeMap(params)
-
-	h := hmac.New(sha256.New, []byte(apiKey))
-	h.Write([]byte(message))
-	securedKey := hex.EncodeToString(h.Sum(nil))
-
-	key = base64.StdEncoding.EncodeToString([]byte(securedKey + message))
 	return
 }
 

--- a/algoliasearch/client_test.go
+++ b/algoliasearch/client_test.go
@@ -819,19 +819,16 @@ func TestDeleteByQuery(t *testing.T) {
 }
 
 func TestGenerateNewSecuredApiKey(t *testing.T) {
-	client, index := initTest(t)
-	defer tearDownTest(t, index)
-
 	base := "182634d8894831d5dbce3b3185c50881"
 
-	key, err := client.GenerateSecuredAPIKey(base, Map{"tagFilters": "(public,user1)"})
+	key, err := GenerateSecuredAPIKey(base, Map{"tagFilters": "(public,user1)"})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	expected := "MDZkNWNjNDY4M2MzMDA0NmUyNmNkZjY5OTMzYjVlNmVlMTk1NTEwMGNmNTVjZmJhMmIwOTIzYjdjMTk2NTFiMnRhZ0ZpbHRlcnM9JTI4cHVibGljJTJDdXNlcjElMjk="
 	checkEqual(t, key, expected, "secured key")
 
-	key, err = client.GenerateSecuredAPIKey(base, Map{"tagFilters": "(public,user1)", "userToken": "42"})
+	key, err = GenerateSecuredAPIKey(base, Map{"tagFilters": "(public,user1)", "userToken": "42"})
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/algoliasearch/secured_api_key.go
+++ b/algoliasearch/secured_api_key.go
@@ -1,0 +1,35 @@
+package algoliasearch
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// GenerateSecuredAPIKey generates a public API key intended to restrict
+// access to certain records. This new key is built upon the existing key
+// named `apiKey` and the `params` map. The `params` map can contain any
+// query parameters to restrict what needs to be and can also have the
+// following fields:
+//   - `userToken` (string identifier generally used to rate-limit users
+//     per IP)
+//   - `validUntil` (timestamp of the expiration date)
+//   - `restrictIndices` (comma-separated string list of the indices to
+//     restrict)
+// More details here:
+// https://www.algolia.com/doc/rest#request-from-browser-with-secure-restriction
+func GenerateSecuredAPIKey(apiKey string, params Map) (key string, err error) {
+	if err = checkGenerateSecuredAPIKey(params); err != nil {
+		return
+	}
+
+	message := encodeMap(params)
+
+	h := hmac.New(sha256.New, []byte(apiKey))
+	h.Write([]byte(message))
+	securedKey := hex.EncodeToString(h.Sum(nil))
+
+	key = base64.StdEncoding.EncodeToString([]byte(securedKey + message))
+	return
+}


### PR DESCRIPTION
From here https://github.com/algolia/algoliasearch-client-go/issues/59