### PR TITLE
Rename API key-related methods to be more consistent with the other API clients

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -37,17 +37,17 @@ type Client interface {
 	// AddKey creates a new API key from the supplied `ACL` and the specified
 	// optional parameters. More details here:
 	// https://www.algolia.com/doc/rest#add-a-global-api-key
-	AddKey(ACL []string, params Map) (res AddKeyRes, err error)
+	AddUserKey(ACL []string, params Map) (res AddKeyRes, err error)
 
 	// UpdateKey updates the API key identified by its value `key` with the
 	// given parameters.
-	UpdateKey(key string, params Map) (res UpdateKeyRes, err error)
+	UpdateUserKey(key string, params Map) (res UpdateKeyRes, err error)
 
 	// GetKey returns the key identified by its value `key`.
-	GetKey(key string) (res Key, err error)
+	GetUserKey(key string) (res Key, err error)
 
 	// DeleteKey deletes the API key identified by its `key`.
-	DeleteKey(key string) (res DeleteRes, err error)
+	DeleteUserKey(key string) (res DeleteRes, err error)
 
 	// GetLogs retrieves the logs according to the given `params` map which can
 	// contain the following fields:
@@ -125,18 +125,18 @@ type Index interface {
 	// AddKey creates a new API key from the supplied `ACL` and the specified
 	// optional `params` parameters for the current index. More details here:
 	// https://www.algolia.com/doc/rest#add-an-index-specific-api-key
-	AddKey(ACL []string, params Map) (res AddKeyRes, err error)
+	AddUserKey(ACL []string, params Map) (res AddKeyRes, err error)
 
 	// UpdateKey updates the key identified by its `key` with all the fields
 	// present in the `params` Map. More details here:
 	// https://www.algolia.com/doc/rest#update-an-index-specific-api-key
-	UpdateKey(key string, params Map) (res UpdateKeyRes, err error)
+	UpdateUserKey(key string, params Map) (res UpdateKeyRes, err error)
 
 	// GetKey retrieves the key identified by its `value`.
-	GetKey(value string) (key Key, err error)
+	GetUserKey(value string) (key Key, err error)
 
 	// DeleteKey deletes the key identified by its `value`.
-	DeleteKey(value string) (res DeleteRes, err error)
+	DeleteUserKey(value string) (res DeleteRes, err error)
 
 	// AddObject adds a new record to the index.
 	AddObject(object Object) (res CreateObjectRes, err error)

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -79,7 +79,7 @@ func (c *client) ClearIndex(name string) (res UpdateTaskRes, err error) {
 	return index.Clear()
 }
 
-func (c *client) AddKey(ACL []string, params Map) (res AddKeyRes, err error) {
+func (c *client) AddUserKey(ACL []string, params Map) (res AddKeyRes, err error) {
 	req := duplicateMap(params)
 	req["acl"] = ACL
 
@@ -91,7 +91,7 @@ func (c *client) AddKey(ACL []string, params Map) (res AddKeyRes, err error) {
 	return
 }
 
-func (c *client) UpdateKey(key string, params Map) (res UpdateKeyRes, err error) {
+func (c *client) UpdateUserKey(key string, params Map) (res UpdateKeyRes, err error) {
 	if err = checkKey(params); err != nil {
 		return
 	}
@@ -101,13 +101,13 @@ func (c *client) UpdateKey(key string, params Map) (res UpdateKeyRes, err error)
 	return
 }
 
-func (c *client) GetKey(key string) (res Key, err error) {
+func (c *client) GetUserKey(key string) (res Key, err error) {
 	path := "/1/keys/" + url.QueryEscape(key)
 	err = c.request(&res, "GET", path, nil, read)
 	return
 }
 
-func (c *client) DeleteKey(key string) (res DeleteRes, err error) {
+func (c *client) DeleteUserKey(key string) (res DeleteRes, err error) {
 	path := "/1/keys/" + url.QueryEscape(key)
 	err = c.request(&res, "DELETE", path, nil, write)
 	return

--- a/algoliasearch/client_test.go
+++ b/algoliasearch/client_test.go
@@ -92,7 +92,7 @@ func hasString(slice []string, elt string) bool {
 
 func waitIndexKey(index Index, key string, f func(Key) bool) {
 	for i := 0; i < 60; i++ {
-		k, err := index.GetKey(key)
+		k, err := index.GetUserKey(key)
 		if err == nil && (f == nil || f(k)) {
 			return
 		}
@@ -102,7 +102,7 @@ func waitIndexKey(index Index, key string, f func(Key) bool) {
 
 func waitMissingIndexKey(index Index, key string) {
 	for i := 0; i < 60; i++ {
-		_, err := index.GetKey(key)
+		_, err := index.GetUserKey(key)
 		if err != nil {
 			return
 		}
@@ -112,7 +112,7 @@ func waitMissingIndexKey(index Index, key string) {
 
 func waitClientKey(client Client, key string, f func(Key) bool) {
 	for i := 0; i < 60; i++ {
-		k, err := client.GetKey(key)
+		k, err := client.GetUserKey(key)
 		if err == nil && (f == nil || f(k)) {
 			return
 		}
@@ -122,7 +122,7 @@ func waitClientKey(client Client, key string, f func(Key) bool) {
 
 func waitMissingClientKey(client Client, key string) {
 	for i := 0; i < 60; i++ {
-		_, err := client.GetKey(key)
+		_, err := client.GetUserKey(key)
 		if err != nil {
 			return
 		}
@@ -514,14 +514,14 @@ func TestAddIndexKey(t *testing.T) {
 		"maxHitsPerQuery":        100,
 	}
 
-	add, err := index.AddKey([]string{"search"}, newKey)
+	add, err := index.AddUserKey([]string{"search"}, newKey)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	waitIndexKey(index, add.Key, nil)
 
-	get, err := index.GetKey(add.Key)
+	get, err := index.GetUserKey(add.Key)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -547,7 +547,7 @@ func TestAddIndexKey(t *testing.T) {
 	}
 
 	updated := Map{"acl": []string{"addObject"}}
-	_, err = index.UpdateKey(add.Key, updated)
+	_, err = index.UpdateUserKey(add.Key, updated)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -571,7 +571,7 @@ func TestAddIndexKey(t *testing.T) {
 		t.Fatalf("%s should be present", add.Key)
 	}
 
-	_, err = index.DeleteKey(add.Key)
+	_, err = index.DeleteUserKey(add.Key)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -606,14 +606,14 @@ func TestAddKey(t *testing.T) {
 		"indexes":                []string{index.name},
 	}
 
-	add, err := client.AddKey(acl, params)
+	add, err := client.AddUserKey(acl, params)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
 	waitClientKey(client, add.Key, nil)
 
-	get, err := client.GetKey(add.Key)
+	get, err := client.GetUserKey(add.Key)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -623,7 +623,7 @@ func TestAddKey(t *testing.T) {
 		t.Fatal("Unable to get a key")
 	}
 
-	_, err = client.UpdateKey(add.Key, Map{"acl": []string{"addObject"}})
+	_, err = client.UpdateUserKey(add.Key, Map{"acl": []string{"addObject"}})
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -647,7 +647,7 @@ func TestAddKey(t *testing.T) {
 		t.Fatalf("%s should be present", add.Key)
 	}
 
-	_, err = client.DeleteKey(add.Key)
+	_, err = client.DeleteUserKey(add.Key)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -137,7 +137,7 @@ func (i *index) ListKeys() (keys []Key, err error) {
 	return
 }
 
-func (i *index) AddKey(ACL []string, params Map) (res AddKeyRes, err error) {
+func (i *index) AddUserKey(ACL []string, params Map) (res AddKeyRes, err error) {
 	req := duplicateMap(params)
 	req["acl"] = ACL
 
@@ -150,7 +150,7 @@ func (i *index) AddKey(ACL []string, params Map) (res AddKeyRes, err error) {
 	return
 }
 
-func (i *index) UpdateKey(key string, params Map) (res UpdateKeyRes, err error) {
+func (i *index) UpdateUserKey(key string, params Map) (res UpdateKeyRes, err error) {
 	if err = checkKey(params); err != nil {
 		return
 	}
@@ -160,13 +160,13 @@ func (i *index) UpdateKey(key string, params Map) (res UpdateKeyRes, err error) 
 	return
 }
 
-func (i *index) GetKey(value string) (key Key, err error) {
+func (i *index) GetUserKey(value string) (key Key, err error) {
 	path := i.route + "/keys/" + url.QueryEscape(value)
 	err = i.client.request(&key, "GET", path, nil, read)
 	return
 }
 
-func (i *index) DeleteKey(value string) (res DeleteRes, err error) {
+func (i *index) DeleteUserKey(value string) (res DeleteRes, err error) {
 	path := i.route + "/keys/" + value
 	err = i.client.request(&res, "DELETE", path, nil, write)
 	return


### PR DESCRIPTION
From #62 