### PR TITLE
Allow for a custom HTTP client to be set

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -1,5 +1,9 @@
 package algoliasearch
 
+import (
+	"net/http"
+)
+
 // Client is a representation of an Algolia application. Once initialized it
 // allows manipulations over the indexes of the application as well as network
 // related parameters.
@@ -10,6 +14,11 @@ type Client interface {
 
 	// SetTimeout specifies timeouts to use with the HTTP connection.
 	SetTimeout(connectTimeout, readTimeout int)
+
+	// SetHTTPClient allows a custom HTTP client to be specified.
+	// NOTE: using this may prevent timeouts set on this client from
+	// working if the underlying transport is not of type *http.Transport.
+	SetHTTPClient(client *http.Client)
 
 	// ListIndexes returns the list of all indexes belonging to this Algolia
 	// application.

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -2,6 +2,7 @@ package algoliasearch
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"time"
 )
@@ -33,6 +34,10 @@ func (c *client) SetExtraHeader(key, value string) {
 
 func (c *client) SetTimeout(connectTimeout, readTimeout int) {
 	c.transport.setTimeout(time.Duration(connectTimeout)*time.Millisecond, time.Duration(readTimeout)*time.Millisecond)
+}
+
+func (c *client) SetHTTPClient(client *http.Client) {
+	c.transport.httpClient = client
 }
 
 func (c *client) ListIndexes() (indexes []IndexRes, err error) {


### PR DESCRIPTION
This added functionality enables the use of alternate transport mechanisms, such as those required for use within Google App Engine [1]. My company has had a branch for a while maintaining this change: https://github.com/rastech/algoliasearch-client-go/commit/59d17d0313aae8d66ed345b4737ee507d358d21e which brings in the appengine libraries as a dependency and is thus probably undesirable for the main repo. Without that [handling](https://github.com/rastech/algoliasearch-client-go/commit/59d17d0313aae8d66ed345b4737ee507d358d21e#diff-606c6ee02e002516ad4f7614a535f7e8R93) for the `*urlfetch.Transport` type, the timeouts won't be properly set, but I put a note in the method comments to that effect.

This also corrects a few minor things from golint.

[1] https://cloud.google.com/appengine/docs/go/outbound-requests