### PR TITLE
Export listIndexesRes.Items so the JSON response can unmarshal into it

### DIFF
--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -39,7 +39,7 @@ func (c *client) ListIndexes() (indexes []IndexRes, err error) {
 	var res listIndexesRes
 
 	err = c.request(&res, "GET", "/1/indexes", nil, read)
-	indexes = res.items
+	indexes = res.Items
 	return
 }
 

--- a/algoliasearch/types_index.go
+++ b/algoliasearch/types_index.go
@@ -2,14 +2,14 @@ package algoliasearch
 
 type IndexRes struct {
 	CreatedAt      string `json:"createdAt"`
-	DataSize       int  `json:"dataSize"`
-	Entries        int  `json:"entries"`
-	LastBuildTimeS int  `json:"lastBuildTimeS"`
+	DataSize       int    `json:"dataSize"`
+	Entries        int    `json:"entries"`
+	LastBuildTimeS int    `json:"lastBuildTimeS"`
 	Name           string `json:"name"`
 	PendingTask    bool   `json:"pendingTask"`
 	UpdatedAt      string `json:"updatedAt"`
 }
 
 type listIndexesRes struct {
-	items []IndexRes
+	Items []IndexRes
 }


### PR DESCRIPTION
This bug fix exports the `Items` field in the `listIndexesRes` struct. This makes it so calls to `ListIndexes()` will be able to get back the Algolia indexes since a field needs to be exported to be unmarshalled from JSON.