### PR TITLE
Add two missing fields to IndexRes struct

### DIFF
--- a/algoliasearch/types_index.go
+++ b/algoliasearch/types_index.go
@@ -1,13 +1,15 @@
 package algoliasearch
 
 type IndexRes struct {
-	CreatedAt      string `json:"createdAt"`
-	DataSize       int    `json:"dataSize"`
-	Entries        int    `json:"entries"`
-	LastBuildTimeS int    `json:"lastBuildTimeS"`
-	Name           string `json:"name"`
-	PendingTask    bool   `json:"pendingTask"`
-	UpdatedAt      string `json:"updatedAt"`
+	CreatedAt           string `json:"createdAt"`
+	DataSize            int    `json:"dataSize"`
+	Entries             int    `json:"entries"`
+	FileSize            int    `json:"fileSize"`
+	LastBuildTimeS      int    `json:"lastBuildTimeS"`
+	Name                string `json:"name"`
+	NumberOfPendingTask int    `json:"numberOfPendingTask"`
+	PendingTask         bool   `json:"pendingTask"`
+	UpdatedAt           string `json:"updatedAt"`
 }
 
 type listIndexesRes struct {


### PR DESCRIPTION
The following fields were missing from the IndexRes struct and have been added:
  - FileSize (integer)
  - NumberOfPendingTask (integer)

From #105 