### PR TITLE
Make the upper-bounded wait time for WaitTask configurable

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -2,6 +2,7 @@ package algoliasearch
 
 import (
 	"net/http"
+	"time"
 )
 
 // Client is a representation of an Algolia application. Once initialized it
@@ -111,8 +112,8 @@ type Index interface {
 	// WaitTask stops the current execution until the task identified by its
 	// `taskID` is finished. The waiting time between each check is usually
 	// implemented by starting at 1s and increases by a factor of 2 at each
-	// retry (but is bounded at around 20min).
-	WaitTask(taskID int) error
+	// retry up to the max sleep duration passed in
+	WaitTask(taskID int, maxSleep time.Duration) error
 
 	// ListKeys lists all the keys that can access the index.
 	ListKeys() (keys []Key, err error)

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -103,7 +103,7 @@ func (i *index) SetSettings(settings Map) (res UpdateTaskRes, err error) {
 	return
 }
 
-func (i *index) WaitTask(taskID int) error {
+func (i *index) WaitTask(taskID int, maxSleep time.Duration) error {
 	var res TaskStatusRes
 	var err error
 
@@ -124,8 +124,9 @@ func (i *index) WaitTask(taskID int) error {
 
 		// Increase the upper boundary used to generate the sleep
 		// duration
-		if maxDuration < 10*time.Minute {
-			maxDuration *= 2
+		maxDuration *= 2
+		if maxDuration < maxSleep {
+			maxDuration = maxSleep
 		}
 	}
 
@@ -433,7 +434,7 @@ func (i *index) DeleteByQuery(query string, params Map) (err error) {
 		}
 
 		// Wait until DeleteObjects completion
-		if err := i.WaitTask(batchRes.TaskID); err != nil {
+		if err := i.WaitTask(batchRes.TaskID, 20*time.Minute); err != nil {
 			return err
 		}
 	}

--- a/algoliasearch/testing.go
+++ b/algoliasearch/testing.go
@@ -4,12 +4,13 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 )
 
 // waitTask waits the task to be finished. If something went wrong, the
 // `testing.T` variable is used to terminate the test case (call to `Fatal`).
 func waitTask(t *testing.T, i Index, taskID int) {
-	err := i.WaitTask(taskID)
+	err := i.WaitTask(taskID, 20*time.Minute)
 	if err != nil {
 		t.Fatalf("waitTask: Task %d not published: %s", taskID, err)
 	}


### PR DESCRIPTION
This PR has `Index.WaitTask` take in a second parameter for the longest possible duration to wait between polling Algolia to see if a task has completed (was 20 minutes)