### PR TITLE
Add GetObjectsAttrs method to get selected attributes of multiple objects

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -98,6 +98,10 @@ type Index interface {
 	// `objectIDs`.
 	GetObjects(objectIDs []string) (objects []Object, err error)
 
+	// GetObjectsAttrs retrieves the selected attributes of the objects
+	// identified according to their `objectIDs`
+	GetObjectsAttrs(objectIDs, attrs []string) (objs []Object, err error)
+
 	// DeleteObject deletes an object from the index that is uniquely
 	// identified by its `objectID`.
 	DeleteObject(objectID string) (res DeleteTaskRes, err error)

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -99,8 +99,8 @@ type Index interface {
 	GetObjects(objectIDs []string) (objects []Object, err error)
 
 	// GetObjectsAttrs retrieves the selected attributes of the objects
-	// identified according to their `objectIDs`
-	GetObjectsAttrs(objectIDs, attrs []string) (objs []Object, err error)
+	// identified according to their `objectIDs`.
+	GetObjectsAttrs(objectIDs, attributesToRetrieve []string) (objs []Object, err error)
 
 	// DeleteObject deletes an object from the index that is uniquely
 	// identified by its `objectID`.

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -54,13 +54,17 @@ func (i *index) GetObject(objectID string, attributes []string) (object Object, 
 	return
 }
 
-func (i *index) getObjects(objectIDs, attrs []string) (objs []Object, err error) {
+func (i *index) getObjects(objectIDs, attributesToRetrieve []string) (objs []Object, err error) {
+	attrs := url.QueryEscape(strings.Join(attributesToRetrieve, ","))
+
 	requests := make([]map[string]string, len(objectIDs))
 	for j, id := range objectIDs {
 		requests[j] = map[string]string{
-			"indexName":  i.name,
-			"objectID":   url.QueryEscape(id),
-			"attributes": url.QueryEscape(strings.Join(attrs, ",")),
+			"indexName": i.name,
+			"objectID":  url.QueryEscape(id),
+		}
+		if attributesToRetrieve != nil {
+			requests[j]["attributesToRetrieve"] = attrs
 		}
 	}
 

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -54,12 +54,13 @@ func (i *index) GetObject(objectID string, attributes []string) (object Object, 
 	return
 }
 
-func (i *index) GetObjects(objectIDs []string) (objs []Object, err error) {
+func (i *index) getObjects(objectIDs, attrs []string) (objs []Object, err error) {
 	requests := make([]map[string]string, len(objectIDs))
 	for j, id := range objectIDs {
 		requests[j] = map[string]string{
-			"indexName": i.name,
-			"objectID":  url.QueryEscape(id),
+			"indexName":  i.name,
+			"objectID":   url.QueryEscape(id),
+			"attributes": url.QueryEscape(strings.Join(attrs, ",")),
 		}
 	}
 
@@ -72,6 +73,14 @@ func (i *index) GetObjects(objectIDs []string) (objs []Object, err error) {
 	err = i.client.request(&res, "POST", path, body, read)
 	objs = res.Results
 	return
+}
+
+func (i *index) GetObjects(objectIDs []string) (objs []Object, err error) {
+	return i.getObjects(objectIDs, nil)
+}
+
+func (i *index) GetObjectsAttrs(objectIDs, attrs []string) (objs []Object, err error) {
+	return i.getObjects(objectIDs, attrs)
 }
 
 func (i *index) DeleteObject(objectID string) (res DeleteTaskRes, err error) {


### PR DESCRIPTION
This PR adds a variation of `GetObjects` that takes in an `attrs` parameter to allow users to retrieve only the selected attributes of multiple objects.