### PR TITLE
checkQuery: simplify ignore query conditions, reduce algorithmic complexity

### DIFF
--- a/algoliasearch/check_query.go
+++ b/algoliasearch/check_query.go
@@ -1,13 +1,20 @@
 package algoliasearch
 
+func buildKeysMap(keys []string) map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, key := range keys {
+		m[key] = struct{}{}
+	}
+
+	return m
+}
+
 func checkQuery(query Map, ignore ...string) error {
-Outer:
+	ignoreKeysMap := buildKeysMap(ignore)
+
 	for k, v := range query {
-		// Continue if `k` is to be ignored.
-		for _, s := range ignore {
-			if s == k {
-				continue Outer
-			}
+		if _, shouldIgnore := ignoreKeysMap[k]; shouldIgnore {
+			continue
 		}
 
 		switch k {


### PR DESCRIPTION
* Refactor checkQuery to take out the continue
label Outer, thus simplifying the code and easing readability.
* Build a map of keys to ignore upfront, so that when iterating over
queries, instead of a quadratic O(n^2) ie O(n*m) lookup time,
it becomes a constant time lookup per query so linear time O(n)
processing altogether where n = max(len(queries), len(ignore)).