### PR TITLE
feat/stateful-conn-with-timer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.6.0 (2016-12-03)
+
+### Fixes
+
+- Improve the transport layer code
+- Keep the last active connection between requests to better handle DNS timeouts
+
+## 2.5.0 (2016-11-29)
+
+### Additions
+
+- Add `Index.SearchForFacetValues` method
+  + Same as `Index.SearchFacet`
+  + `Index.SearchFacet` is kept for backward-compatibility
+
 ## 2.4.0 (2016-11-02)
 
 ### Changes

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -33,7 +33,10 @@ func (c *client) SetExtraHeader(key, value string) {
 }
 
 func (c *client) SetTimeout(connectTimeout, readTimeout int) {
-	c.transport.setTimeout(time.Duration(connectTimeout)*time.Millisecond, time.Duration(readTimeout)*time.Millisecond)
+	c.transport.setTimeout(
+		time.Duration(connectTimeout)*time.Millisecond,
+		time.Duration(readTimeout)*time.Millisecond,
+	)
 }
 
 func (c *client) SetHTTPClient(client *http.Client) {

--- a/algoliasearch/client_test.go
+++ b/algoliasearch/client_test.go
@@ -405,3 +405,19 @@ func TestSlaveReplica(t *testing.T) {
 		t.Fatalf("TestSlaveReplica: Replicas settings are not the same:\nExpected:%s\nGot:%s", replicas, settings.Replicas)
 	}
 }
+
+func TestDnsTimeout(t *testing.T) {
+	t.Parallel()
+
+	client := initClientWithTimeoutHosts(t)
+
+	start := time.Now()
+	for i := 0; i < 10; i++ {
+		client.ListIndexes()
+	}
+	delta := time.Now().Sub(start)
+
+	if delta > 5*time.Second {
+		t.Fatalf("TestDnsTimeout: Spent %d seconds instead of <5s to perform the 10 retries", int(delta.Seconds()))
+	}
+}

--- a/algoliasearch/testing_test.go
+++ b/algoliasearch/testing_test.go
@@ -71,10 +71,7 @@ func initClientWithTimeoutHosts(t *testing.T) Client {
 		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID and/or ALGOLIA_API_KEY")
 	}
 
-	return NewClientWithHosts(appID, apiKey, []string{
-		"algolia.biz",
-		appID + "-dsn.algolia.net",
-	})
+	return NewClientWithHosts(appID, apiKey, []string{"algolia.biz"})
 }
 
 // initIndex init the `c` client with the index called `name`. It also deletes

--- a/algoliasearch/testing_test.go
+++ b/algoliasearch/testing_test.go
@@ -60,6 +60,23 @@ func initClient(t *testing.T) Client {
 	return NewClient(appID, apiKey)
 }
 
+// initClientWithHosts instantiates a new client according to the
+// `ALGOLIA_APPLICATION_ID` and `ALGOLIA_API_KEY` environment variables and set
+// one of the host to specifically timeout.
+func initClientWithTimeoutHosts(t *testing.T) Client {
+	appID := os.Getenv("ALGOLIA_APPLICATION_ID")
+	apiKey := os.Getenv("ALGOLIA_API_KEY")
+
+	if appID == "" || apiKey == "" {
+		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID and/or ALGOLIA_API_KEY")
+	}
+
+	return NewClientWithHosts(appID, apiKey, []string{
+		"algolia.biz",
+		appID + "-dsn.algolia.net",
+	})
+}
+
 // initIndex init the `c` client with the index called `name`. It also deletes
 // the index if it was existing beforehand. It waits until the task is
 // finished.

--- a/algoliasearch/transport.go
+++ b/algoliasearch/transport.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	version = "2.0.0"
+	version = "2.6.0"
 )
 
 // Define the constants used to specify the type of request.

--- a/algoliasearch/transport.go
+++ b/algoliasearch/transport.go
@@ -233,7 +233,7 @@ func (t *Transport) tryRequest(method, host, path string, body interface{}) ([]b
 
 	// Return the body as an error if the status code is not 2XX
 	code := res.StatusCode
-	if code < 200 || 300 <= code {
+	if !(200 <= code && code < 300) {
 		return nil, errors.New(string(bodyRes))
 	}
 


### PR DESCRIPTION
This PR implements the new retry strategy discussed internally. It also improves the overall code of `algoliasearch/transport.go` which were the only remaining file still unmodified after the v1-v2 migration.