### PR TITLE
Fix unlimited socket opening problem

### DIFF
--- a/algoliasearch/transport.go
+++ b/algoliasearch/transport.go
@@ -242,13 +242,13 @@ func (t *Transport) tryRequest(method, host, path string, body interface{}) ([]b
 	if err != nil {
 		return nil, fmt.Errorf("Cannot perform request [%s] %s (%s): %s", method, path, host, err)
 	}
+	defer res.Body.Close()
 
 	// Read response's body
 	bodyRes, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot read response body: %s", err)
 	}
-	res.Body.Close()
 
 	// Return the body as an error if the status code is not 2XX
 	code := res.StatusCode


### PR DESCRIPTION
transport.go#L171 tries to make a request to each host, until one
succeed and ignore errors unless there is no host left. But
transport.go#L249 can return with an error before closing
the response at L251. This error is not caught by Transport.request()
method unless there no other host to try.
Consequence of transport.go#L249 is that with a lot number of calls we
can arrive at a situation with a lot of socket remained open.
This commit fix the problem by defering the connection closure and move
the statement before any error can happen so that in any situation the
socket is closed.

CAT: #fix
REF: algolia/algoliasearch-client-go#287