### PR TITLE
Fix query format in GetObject and GetObjectsAttrs

### DIFF
--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -45,7 +45,7 @@ func (i *index) GetObject(objectID string, attributes []string) (object Object, 
 			return
 		}
 		params = Map{
-			"attributes": attrBytes,
+			"attributes": string(attrBytes),
 		}
 	}
 
@@ -55,7 +55,7 @@ func (i *index) GetObject(objectID string, attributes []string) (object Object, 
 }
 
 func (i *index) getObjects(objectIDs, attributesToRetrieve []string) (objs []Object, err error) {
-	attrs := url.QueryEscape(strings.Join(attributesToRetrieve, ","))
+	attrs := strings.Join(attributesToRetrieve, ",")
 
 	requests := make([]map[string]string, len(objectIDs))
 	for j, id := range objectIDs {


### PR DESCRIPTION
This PR fixes a bug retrieving attributes in the `index`'s `GetObjectsAttrs` and `GetObject` methods. In `GetObjectsAttrs`, the requested list of attributes is URL-escaped, while in `GetObject`, the attribute query params being passed into `encodeParams` are a `[]byte`, rather than a `string`. The result, in both cases, is that no attributes except the object ID are retrieved.