### PR TITLE
Add standard http.ProxyFromEnvironment to default transport

### DIFF
--- a/algoliasearch/transport.go
+++ b/algoliasearch/transport.go
@@ -124,6 +124,7 @@ func defaultHttpClient() *http.Client {
 // lookup timeouts).
 func defaultTransport(dialTimeout time.Duration) *http.Transport {
 	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			KeepAlive: 180 * time.Second,
 			Timeout:   dialTimeout,


### PR DESCRIPTION
This is required for applications that limit outbound http/https access to a proxy server to connect to their Algolia servers, and really use this client library at all. 

The current implementation exposes a method to overwrite the underlying `*http.Client` that powers this client lib, but then when requests are made it is overwritten almost immediately whenever [`increaseDialTimeout`](https://github.com/algolia/algoliasearch-client-go/blob/master/algoliasearch/transport.go#L311) or [`resetDialTimeout`](https://github.com/algolia/algoliasearch-client-go/blob/master/algoliasearch/transport.go#L318) are called.