### PR TITLE
Improve DeleteByQuery performance

### DIFF
--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -457,6 +457,7 @@ func (i *index) DeleteByQuery(query string, params Map) (err error) {
 	copy["distinct"] = 0
 
 	var browseRes BrowseRes
+	var batchRes BatchRes
 	var objectIDs []string
 	var cursor string
 
@@ -481,8 +482,13 @@ func (i *index) DeleteByQuery(query string, params Map) (err error) {
 	}
 
 	// Delete all the objects
-	if _, err = i.DeleteObjects(objectIDs); err != nil {
+	if batchRes, err = i.DeleteObjects(objectIDs); err != nil {
 		return
+	}
+
+	// Wait until DeleteObjects completion
+	if err := i.WaitTask(batchRes.TaskID); err != nil {
+		return err
 	}
 
 	return nil

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -121,7 +121,7 @@ func (i *index) WaitTask(taskID int) error {
 	var res TaskStatusRes
 	var err error
 
-	var maxDuration time.Duration = time.Second
+	var maxDuration = time.Second
 	var sleepDuration time.Duration
 
 	for {
@@ -142,8 +142,6 @@ func (i *index) WaitTask(taskID int) error {
 			maxDuration *= 2
 		}
 	}
-
-	return nil
 }
 
 func (i *index) ListKeys() (keys []Key, err error) {


### PR DESCRIPTION
As discussed here: https://github.com/algolia/algoliasearch-client-ruby/pull/211 this the same implementation for go.

Update: I've added wait for DeleteObjects to match [documentation](https://www.algolia.com/doc/api-client/go/indexing/#delete-by-query), but I think it should be like other functions and like documentation said: "All write operations in Algolia are asynchronous by design".
```go
func (i *index) DeleteByQuery(query string, params Map) (res BatchRes, err error) {
	copy := duplicateMap(params)
	copy["attributesToRetrieve"] = []string{"objectID"}
	copy["hitsPerPage"] = 1000
	copy["query"] = query
	copy["distinct"] = 0

	var browseRes BrowseRes
	var objectIDs []string
	var cursor string

	for {
		// Start browsing the content by cursor
		if browseRes, err = i.Browse(copy, cursor); err != nil {
			return
		}

		// Break if there's no more matching records
		if len(browseRes.Hits) == 0 {
			break
		}

		// Collect all objectIDs
		for _, hit := range browseRes.Hits {
			objectIDs = append(objectIDs, hit["objectID"].(string))
		}

		// Set the new cursor from response
		cursor = browseRes.Cursor
	}

	// Delete all the objects
	if res, err = i.DeleteObjects(objectIDs); err != nil {
		return
	}

	return
}
```
