### PR TITLE
Add missing removeWordsIfNoResults to settings type

### DIFF
--- a/algoliasearch/types_settings.go
+++ b/algoliasearch/types_settings.go
@@ -52,6 +52,7 @@ type Settings struct {
 	SnippetEllipsisText        string      `json:"snippetEllipsisText"`
 	SortFacetValuesBy          string      `json:"sortFacetValuesBy"`
 	TypoTolerance              string      `json:"typoTolerance"`
+	RemoveWordsIfNoResults     string      `json:"removeWordsIfNoResults"`
 }
 
 // clean sets the nil `interface{}` fields of any `Settings struct` generated
@@ -121,6 +122,7 @@ func (s *Settings) ToMap() Map {
 		"snippetEllipsisText":        s.SnippetEllipsisText,
 		"typoTolerance":              s.TypoTolerance,
 		"responseFields":             s.ResponseFields,
+		"removeWordsIfNoResults":     s.RemoveWordsIfNoResults,
 	}
 
 	// Remove empty string slices to avoid creating null-valued fields in the


### PR DESCRIPTION
The setting is already returned in the settings API, but was never exposed in the settings type.