### PR TITLE
Add clickAnalytics to search option parameters

### DIFF
--- a/algoliasearch/check_query.go
+++ b/algoliasearch/check_query.go
@@ -55,6 +55,7 @@ Outer:
 		case "allowTyposOnNumericTokens",
 			"advancedSyntax",
 			"analytics",
+			"clickAnalytics",
 			"synonyms",
 			"replaceSynonymsInHighlight",
 			"aroundLatLngViaIP",

--- a/algoliasearch/client_test.go
+++ b/algoliasearch/client_test.go
@@ -304,6 +304,10 @@ func TestMultipleQueries(t *testing.T) {
 			IndexName: "TestMultipleQueries_products",
 			Params:    Map{"query": "computer", "hitsPerPage": 4},
 		},
+		{
+			IndexName: "TestMultipleQueries_products",
+			Params:    Map{"query": "computer", "clickAnalytics": true},
+		},
 	}
 
 	res, err := c.MultipleQueries(queries, "")
@@ -312,8 +316,8 @@ func TestMultipleQueries(t *testing.T) {
 		t.Fatalf("TestMultipleQueries: Cannot send multiple queries: %s", err)
 	}
 
-	if len(res) != 3 {
-		t.Fatalf("TestMultipleQueries: Should return 3 MultipleQueryRes instead of %d", len(res))
+	if len(res) != 4 {
+		t.Fatalf("TestMultipleQueries: Should return 4 MultipleQueryRes instead of %d", len(res))
 	}
 
 	if len(res[0].Hits) != 1 {
@@ -326,6 +330,10 @@ func TestMultipleQueries(t *testing.T) {
 
 	if len(res[2].Hits) != 3 {
 		t.Fatalf("TestMultipleQueries: Third query should return 3 records instead of %d", len(res[2].Hits))
+	}
+
+	if res[3].QueryID == "" {
+		t.Fatal("TestMultipleQueries: Fourth query should return queryID")
 	}
 }
 

--- a/algoliasearch/index_test.go
+++ b/algoliasearch/index_test.go
@@ -544,6 +544,21 @@ func TestIndexingAndSearch(t *testing.T) {
 		}
 	}
 
+	t.Log("TestIndexingAndSearch: Search for \"elon musk\" with \"(clickAnalytics:true)\" parameter")
+	{
+		params := Map{
+			"clickAnalytics": true,
+		}
+		res, err := i.Search("elon musk", params)
+		if err != nil {
+			t.Fatalf("TestIndexingAndSearch: Search for 'elon musk' with clickAnalytics option failed: %s", err)
+		}
+
+		if res.QueryID == "" {
+			t.Fatalf("TestIndexingAndSearch: Should return QueryID")
+		}
+	}
+
 	t.Log("TestIndexingAndSearch: Iterate and collect over all the records' `objectID`")
 	var objectIDs []string
 	{

--- a/algoliasearch/types_query.go
+++ b/algoliasearch/types_query.go
@@ -30,6 +30,7 @@ type QueryRes struct {
 	ProcessingTimeMS      int    `json:"processingTimeMS"`
 	Query                 string `json:"query"`
 	QueryAfterRemoval     string `json:"queryAfterRemoval"`
+	QueryID               string `json:"queryID"`
 	ServerUsed            string `json:"serverUsed"`
 	TimeoutCounts         bool   `json:"timeoutCounts"`
 	TimeoutHits           bool   `json:"timeoutHits"`


### PR DESCRIPTION
## Overview

* Added `clickAnalytics` boolean parameter to acceptable search options
* Added `queryID` to search response

## Whey we need it

When we implement Click Analytics feature, we need to add `clickAnalytics: true` to search option.
https://www.algolia.com/doc/tutorials/getting-started/how-to-implement-analytics/

And when we activate Click Analytics, the search response contains `queryID` parameter. We need to retrieve it from the response.

## After merging this PR

We can set `clickAnalytics` parameter and get `queryID` from the search response. It means we can use Click Analytics feature with golang SDK.