### PR TITLE
Add golang version to UserAgent

### DIFF
--- a/algoliasearch/transport.go
+++ b/algoliasearch/transport.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -90,7 +91,7 @@ func NewTransportWithHosts(appId, apiKey string, hosts []string) *Transport {
 func defaultHeaders(appId, apiKey string) map[string]string {
 	return map[string]string{
 		"Connection":               "keep-alive",
-		"User-Agent":               "Algolia for Go (" + version + ")",
+		"User-Agent":               fmt.Sprintf("Algolia for Go (%s); Go (%s); ", version, runtime.Version()),
 		"X-Algolia-API-Key":        apiKey,
 		"X-Algolia-Application-Id": appId,
 	}


### PR DESCRIPTION
`runtime.Version()` returns something like "go1.10.1", I believe it's best to remove the first 2 characters.