### PR TITLE
fix(key): Add QueryParameters in Key struct to fix typo

### DIFF
--- a/algoliasearch/types_key.go
+++ b/algoliasearch/types_key.go
@@ -7,7 +7,7 @@ type Key struct {
 	Indexes                []string `json:"indexes,omitempty"`
 	MaxHitsPerQuery        int      `json:"maxHitsPerQuery,omitempty"`
 	MaxQueriesPerIPPerHour int      `json:"maxQueriesPerIPPerHour,omitempty"`
-	QueryParamaters        string   `json:"queryParameters,omitempty"`
+	QueryParameters        string   `json:"queryParameters,omitempty"`
 	Referers               []string `json:"referers,omitempty"`
 	Validity               int      `json:"validity,omitempty"`
 	Value                  string   `json:"value,omitempty"`


### PR DESCRIPTION
There is a typo in QueryParameters. I am not sure this is the right way to fix it, there might be side effects that I haven't considered.

Feel free to update or close, or let me know what to do.