### PR TITLE
fix: Expose missing fields related to Query Rules

### DIFF
--- a/algoliasearch/check_query.go
+++ b/algoliasearch/check_query.go
@@ -56,6 +56,7 @@ Outer:
 			"advancedSyntax",
 			"analytics",
 			"clickAnalytics",
+			"enableRules",
 			"synonyms",
 			"replaceSynonymsInHighlight",
 			"aroundLatLngViaIP",

--- a/algoliasearch/check_settings.go
+++ b/algoliasearch/check_settings.go
@@ -29,6 +29,7 @@ func checkSettings(settings Map) error {
 		case "allowCompressionOfIntegerArray",
 			"advancedSyntax",
 			"allowTyposOnNumericTokens",
+			"enableRules",
 			"replaceSynonymsInHighlight",
 			"forwardToSlaves",
 			"forwardToReplicas",

--- a/algoliasearch/types_query.go
+++ b/algoliasearch/types_query.go
@@ -11,15 +11,17 @@ type MultipleQueryRes struct {
 }
 
 type QueryRes struct {
+	AppliedRules          []Map  `json:"appliedRules"`
 	AroundLatLng          string `json:"aroundLatLng"`
 	AutomaticRadius       string `json:"automaticRadius"`
 	ExhaustiveFacetsCount bool   `json:"exhaustiveFacetsCount"`
-	Facets                Map    `json:"facets"`
 	ExhaustiveNbHits      bool   `json:"exhaustiveNbHits"`
+	Facets                Map    `json:"facets"`
 	FacetsStats           Map    `json:"facets_stats"`
 	Hits                  []Map  `json:"hits"`
 	HitsPerPage           int    `json:"hitsPerPage"`
 	Index                 string `json:"index"`
+	IndexUsed             string `json:"indexUsed"`
 	Length                int    `json:"length"`
 	Message               string `json:"message"`
 	NbHits                int    `json:"nbHits"`
@@ -35,6 +37,7 @@ type QueryRes struct {
 	ServerUsed            string `json:"serverUsed"`
 	TimeoutCounts         bool   `json:"timeoutCounts"`
 	TimeoutHits           bool   `json:"timeoutHits"`
+	UserData              []Map  `json:"userData"`
 }
 
 type IndexedQuery struct {

--- a/algoliasearch/types_settings.go
+++ b/algoliasearch/types_settings.go
@@ -36,6 +36,7 @@ type Settings struct {
 	AttributesToRetrieve              []string    `json:"attributesToRetrieve"`
 	AttributesToSnippet               []string    `json:"attributesToSnippet"`
 	Distinct                          interface{} `json:"distinct"` // float64 (actually an int) or bool
+	EnableRules                       bool        `json:"enableRules"`
 	HighlightPostTag                  string      `json:"highlightPostTag"`
 	HighlightPreTag                   string      `json:"highlightPreTag"`
 	HitsPerPage                       int         `json:"hitsPerPage"`


### PR DESCRIPTION
After investigation, we discovered that some query rules fields were
missing here and there. This commit now exposes the following fields:

 - `enableRules` boolean as a query parameter
 - `enableRules` boolean as a setting
 - `appliedRules` slice of maps in the query response
 - `indexUsed` string in the query response
 - `userData` slice of maps in the query response