### PR TITLE
feat(client): Expose waitTask in the client

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -178,6 +178,23 @@ type Client interface {
 	// BatchWithRequestOptions is the same as Batch but it also accepts extra
 	// RequestOptions.
 	BatchWithRequestOptions(operations []BatchOperationIndexed, opts *RequestOptions) (res MultipleBatchRes, err error)
+
+	// WaitTask stops the current execution until the task identified by its
+	// `taskID` on the index `indexName` is finished. The waiting time between each check is usually
+	// implemented by starting at 1s and increases by a factor of 2 at each
+	// retry (but is bounded at around 20min).
+	WaitTask(indexName string, taskID int) error
+
+	// WaitTaskWithRequestOptions is the same as WaitTask but it also accepts
+	// extra RequestOptions.
+	WaitTaskWithRequestOptions(indexName string, taskID int, opts *RequestOptions) error
+
+	// GetStatus returns the status of a task given its ID `taskID` and `indexName`.
+	GetStatus(indexName string, taskID int) (res TaskStatusRes, err error)
+
+	// GetStatusWithRequestOptions is the same as GetStatus but it also accepts
+	// extra RequestOptions.
+	GetStatusWithRequestOptions(indexName string, taskID int, opts *RequestOptions) (res TaskStatusRes, err error)
 }
 
 // Index is a representation used to manipulate an Algolia index.

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 )
 
 type index struct {
@@ -154,30 +153,7 @@ func (i *index) WaitTask(taskID int) error {
 }
 
 func (i *index) WaitTaskWithRequestOptions(taskID int, opts *RequestOptions) error {
-	var res TaskStatusRes
-	var err error
-
-	var maxDuration = time.Second
-	var sleepDuration time.Duration
-
-	for {
-		if res, err = i.GetStatusWithRequestOptions(taskID, opts); err != nil {
-			return err
-		}
-
-		if res.Status == "published" {
-			return nil
-		}
-
-		sleepDuration = randDuration(maxDuration)
-		time.Sleep(sleepDuration)
-
-		// Increase the upper boundary used to generate the sleep
-		// duration
-		if maxDuration < 10*time.Minute {
-			maxDuration *= 2
-		}
-	}
+	return i.client.WaitTaskWithRequestOptions(i.name, taskID, opts)
 }
 
 func (i *index) ListKeys() (keys []Key, err error) {
@@ -449,8 +425,7 @@ func (i *index) GetStatus(taskID int) (res TaskStatusRes, err error) {
 }
 
 func (i *index) GetStatusWithRequestOptions(taskID int, opts *RequestOptions) (res TaskStatusRes, err error) {
-	path := i.route + fmt.Sprintf("/task/%d", taskID)
-	err = i.client.request(&res, "GET", path, nil, read, opts)
+	res, err = i.client.GetStatusWithRequestOptions(i.name, taskID, opts)
 	return
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes (not sure)


## What was changed

The 2 methods about taskID initially available in the `Index` moved to the `Client`. The original methods on the index still work are **not** deprecated.

## Why it was changed

You could get some taskID from the engine without necessarily having an instance of Index. Instead of instantiating an index that you won't need, you can now call `QaitTask` and `GetStatus` on the client.

* It will be very useful for the new Analytics object (see https://github.com/algolia/algoliasearch-client-php/pull/408)
* We're planning to merge https://github.com/algolia/algoliasearch-client-php/pull/295 (and port it to all clients). Adding multipleObjects will be easier to use if QaitTask lives in the Client.
* It was also discussed before for the Django integration ([here](https://github.com/algolia/algoliasearch-django/pull/258)).
