### PR TITLE
fix: Export missing attributes in Settings.ToMap

### DIFF
--- a/algoliasearch/types_settings.go
+++ b/algoliasearch/types_settings.go
@@ -80,12 +80,20 @@ func (s *Settings) clean() {
 	if s.MaxFacetHits == 0 {
 		s.MaxFacetHits = 10
 	}
+
+	if s.SortFacetValuesBy == "" {
+		s.SortFacetValuesBy = "count"
+	}
 }
 
 // ToMap produces a `Map` corresponding to the `Settings struct`. It should
 // only be used when it's needed to pass a `Settings struct` to `SetSettings`,
 // typically when one needs to copy settings between two indices.
 func (s *Settings) ToMap() Map {
+	// Guarantee that interface{}-typed fields and default values are correctly
+	// set.
+	s.clean()
+
 	// Add all fields except:
 	//  - Distinct float64 or bool
 	//  - IgnorePlurals []interface{} or bool
@@ -117,9 +125,11 @@ func (s *Settings) ToMap() Map {
 		"attributesToHighlight":             s.AttributesToHighlight,
 		"attributesToRetrieve":              s.AttributesToRetrieve,
 		"attributesToSnippet":               s.AttributesToSnippet,
+		"enableRules":                       s.EnableRules,
 		"highlightPostTag":                  s.HighlightPostTag,
 		"highlightPreTag":                   s.HighlightPreTag,
 		"hitsPerPage":                       s.HitsPerPage,
+		"ignorePlurals":                     s.IgnorePlurals,
 		"maxFacetHits":                      s.MaxFacetHits,
 		"maxValuesPerFacet":                 s.MaxValuesPerFacet,
 		"minProximity":                      s.MinProximity,
@@ -132,6 +142,7 @@ func (s *Settings) ToMap() Map {
 		"responseFields":                    s.ResponseFields,
 		"restrictHighlightAndSnippetArrays": s.RestrictHighlightAndSnippetArrays,
 		"snippetEllipsisText":               s.SnippetEllipsisText,
+		"sortFacetValuesBy":                 s.SortFacetValuesBy,
 		"typoTolerance":                     s.TypoTolerance,
 	}
 


### PR DESCRIPTION


| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | N/A
| Need Doc update   | no


The following attributes were missing in the result Map returned by the
Settings.ToMap function:
 * `enableRules`
 * `ignorePlurals`
 * `sortFacetValuesBy`

Also, some fields may not have been properly transformed because the
Settings.clean function was not called to clean some fields with sane
defaults.

This commits fixes all the aformentioned issues and adds a test to
ensure that any new field added to the Settings struct will make the
tests fail in not handled in the Settings.ToMap function.