### PR TITLE
Query rules v2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -31,6 +39,9 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["github.com/stretchr/testify/require"]
+  input-imports = [
+    "github.com/mitchellh/mapstructure",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,6 +29,10 @@
   name = "github.com/stretchr/testify"
   version = "~1.2.2"
 
+[[constraint]]
+  name = "github.com/mitchellh/mapstructure"
+  branch = "master"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/algoliasearch/check_query.go
+++ b/algoliasearch/check_query.go
@@ -32,6 +32,7 @@ Outer:
 			"attributesToSnippet",
 			"disableExactOnAttributes",
 			"disableTypoToleranceOnAttributes",
+			"explain",
 			"queryLanguages",
 			"responseFields":
 			if _, ok := v.([]string); !ok {

--- a/algoliasearch/check_rule.go
+++ b/algoliasearch/check_rule.go
@@ -30,16 +30,19 @@ func checkRules(rules []Rule) error {
 
 			case "query":
 				switch v.(type) {
-				case string, QueryIncrementalEdit:
+				case string, QueryIncrementalEdit, Map:
 					// OK
 				default:
-					return invalidType(k, "string or QueryIncrementalEdit")
+					return invalidType(k, "string or QueryIncrementalEdit or Map")
 				}
 
 			case "automaticFacetFilters",
 				"automaticOptionalFacetFilters":
-				if _, ok := v.([]string); !ok {
-					return invalidType(k, "[]string")
+				switch v.(type) {
+				case []string, []AutomaticFacetFilter:
+					// OK
+				default:
+					return invalidType(k, "[]string or []AutomaticFacetFilter")
 				}
 
 			default:

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -682,6 +682,8 @@ func (i *index) SaveRuleWithRequestOptions(rule Rule, forwardToReplicas bool, op
 		return
 	}
 
+	rule.enableImplicitly()
+
 	params := Map{"forwardToReplicas": forwardToReplicas}
 	path := i.route + "/rules/" + rule.ObjectID + "?" + encodeMap(params)
 	err = i.client.request(&res, "PUT", path, rule, write, opts)
@@ -695,6 +697,10 @@ func (i *index) BatchRules(rules []Rule, forwardToReplicas, clearExistingRules b
 func (i *index) BatchRulesWithRequestOptions(rules []Rule, forwardToReplicas, clearExistingRules bool, opts *RequestOptions) (res BatchRulesRes, err error) {
 	if err = checkRules(rules); err != nil {
 		return
+	}
+
+	for i, _ := range rules {
+		rules[i].enableImplicitly()
 	}
 
 	params := Map{

--- a/algoliasearch/types_query.go
+++ b/algoliasearch/types_query.go
@@ -16,6 +16,7 @@ type QueryRes struct {
 	AutomaticRadius       string `json:"automaticRadius"`
 	ExhaustiveFacetsCount bool   `json:"exhaustiveFacetsCount"`
 	ExhaustiveNbHits      bool   `json:"exhaustiveNbHits"`
+	Explain               Map    `json:"explain"`
 	Facets                Map    `json:"facets"`
 	FacetsStats           Map    `json:"facets_stats"`
 	Hits                  []Map  `json:"hits"`

--- a/algoliasearch/types_rule.go
+++ b/algoliasearch/types_rule.go
@@ -1,11 +1,35 @@
 package algoliasearch
 
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
 type Rule struct {
-	ObjectID        string          `json:"objectID,omitempty"`
-	Condition       RuleCondition   `json:"condition"`
-	Consequence     RuleConsequence `json:"consequence"`
-	Description     string          `json:"description,omitempty"`
-	HighlightResult Map             `json:"_highlightResult,omitempty"`
+	Condition            RuleCondition   `json:"condition"`
+	Consequence          RuleConsequence `json:"consequence"`
+	Description          string          `json:"description,omitempty"`
+	Enabled              bool            `json:"enabled"` // Defaults to true
+	HighlightResult      Map             `json:"_highlightResult,omitempty"`
+	ObjectID             string          `json:"objectID,omitempty"`
+	Validity             []TimeRange     `json:"validity,omitempty"`
+	isExplicitlyDisabled bool
+}
+
+func (r *Rule) Enable() {
+	r.Enabled = true
+}
+
+func (r *Rule) Disable() {
+	r.Enabled = false
+	r.isExplicitlyDisabled = true
+}
+
+func (r *Rule) enableImplicitly() {
+	if !r.isExplicitlyDisabled {
+		r.Enable()
+	}
 }
 
 // RuleCondition is the part of an Algolia Rule which describes the condition
@@ -46,16 +70,81 @@ func NewRuleCondition(anchoring RulePatternAnchoring, pattern, context string) R
 type RuleConsequence struct {
 	Params   Map              `json:"params,omitempty"`
 	Promote  []PromotedObject `json:"promote,omitempty"`
+	Hide     []HiddenObject   `json:"hide,omitempty"`
 	UserData interface{}      `json:"userData,omitempty"`
 }
 
+// AutomaticFacetFilter
+type AutomaticFacetFilter struct {
+	Facet       string `json:"facet"`
+	Disjunctive bool   `json:"disjunctive"` // Defaults to false
+	Score       int    `json:"score"`
+}
+
+// QueryIncrementalEdit can be used as a value for the `query` key when used in
+// the `RuleConsequence.Params` map. It is used to remove specific words from
+// the original query string.
+//
+// Deprecated: Use `DeleteEdit` instead. More specifically, code previously
+// written this way:
+//
+//  consequence := algoliasearch.RuleConsquence{
+//  	Params: algoliasearch.Map{
+//  		"query": algoliasearch.QueryIncrementalEdit{
+//  			Remove: []string{"term1", "term2"},
+//  		},
+//  	},
+//  }
+//
+// should now be written:
+//
+//  consequence := algoliasearch.RuleConsequence{
+//  	Params: algoliasearch.Map{
+//  		"query": algoliasearch.Map{
+//  			"edits": []algoliasearch.Edit{
+//  				algoliasearch.DeleteEdit("term1"),
+//  				algoliasearch.DeleteEdit("term2"),
+//  			},
+//  		},
+//  	},
+//  }
+//
 type QueryIncrementalEdit struct {
 	Remove []string `json:"remove"`
+}
+
+type Edit struct {
+	Type   string `json:"type"`
+	Delete string `json:"delete"`
+	Insert string `json:"insert,omitempty"`
+}
+
+// DeleteEdit returns a new `Edit` instance used to remove the given `word`
+// from an original query when used as a `RuleConsequence.Params`.
+func DeleteEdit(word string) Edit {
+	return Edit{
+		Type:   "remove",
+		Delete: word,
+	}
+}
+
+// ReplaceEdit returns a new `Edit` instance used to replace the given `old`
+// term with `new` in a query when used as a `RuleConsequence.Params`.
+func ReplaceEdit(old, new string) Edit {
+	return Edit{
+		Type:   "replace",
+		Delete: old,
+		Insert: new,
+	}
 }
 
 type PromotedObject struct {
 	ObjectID string `json:"objectID"`
 	Position int    `json:"position"`
+}
+
+type HiddenObject struct {
+	ObjectID string `json:"objectID"`
 }
 
 type SaveRuleRes struct {
@@ -76,6 +165,39 @@ type DeleteRuleRes struct {
 type ClearRulesRes struct {
 	TaskID    int    `json:"taskID"`
 	UpdatedAt string `json:"updatedAt"`
+}
+
+type TimeRange struct {
+	From  time.Time
+	Until time.Time
+}
+
+type timeRangeResponse struct {
+	From  int64 `json:"from"`
+	Until int64 `json:"until"`
+}
+
+func (r TimeRange) MarshalJSON() ([]byte, error) {
+	data := fmt.Sprintf(
+		`{"from":%d,"until":%d}`,
+		r.From.Unix(),
+		r.Until.Unix(),
+	)
+	return []byte(data), nil
+}
+
+func (r *TimeRange) UnmarshalJSON(b []byte) error {
+	var res timeRangeResponse
+
+	err := json.Unmarshal(b, &res)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal integer values of time range: %s", err)
+	}
+
+	r.From = time.Unix(res.From, 0)
+	r.Until = time.Unix(res.Until, 0)
+
+	return nil
 }
 
 type SearchRulesRes struct {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | yes


## What was changed

All changes related to the release of Query Rules v2. For detailled informations, please take a look at the dedicated commit. Other commits simply add the associated tests and introduce a new dependency on github.com/mitchellh/mapstructure now used in tests only to ease response objects comparison.

## Why it was changed

New features available from the engine.