### PR TITLE
fix: objectID is required to deleteObject

### DIFF
--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -111,6 +111,11 @@ func (i *index) DeleteObject(objectID string) (res DeleteTaskRes, err error) {
 }
 
 func (i *index) DeleteObjectWithRequestOptions(objectID string, opts *RequestOptions) (res DeleteTaskRes, err error) {
+	if objectID == "" {
+		err = fmt.Errorf("objectID cannot be empty")
+		return
+	}
+
 	path := i.route + "/" + url.QueryEscape(objectID)
 	err = i.client.request(&res, "DELETE", path, nil, write, opts)
 	return

--- a/algoliasearch/index_test.go
+++ b/algoliasearch/index_test.go
@@ -766,6 +766,9 @@ func TestIndexingAndSearch(t *testing.T) {
 		}
 		hit := queryRes.Hits[0]
 
+		_, err = i.DeleteObject("")
+		require.Error(t, err)
+
 		res, err := i.DeleteObject(hit["objectID"].(string))
 		if err != nil {
 			t.Fatalf("TestIndexingAndSearch: Cannot delete 'jeff bezos' record: %s", err)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## What was changed

`Index::delete_object` needs a non-empty objectID

## Why it was changed

If the object_id is empty, the entire index will be deleted instead of one record.