### PR TITLE
fix: Add missing types for `facetFilters`

### DIFF
--- a/algoliasearch/check_query.go
+++ b/algoliasearch/check_query.go
@@ -105,10 +105,17 @@ Outer:
 				return invalidType(k, "string or []interface{}")
 			}
 
+		case "facetFilters":
+			switch v.(type) {
+			case string, []string, [][]string, []interface{}:
+				//OK
+			default:
+				return invalidType(k, "string, []string, [][]string or []interface{}")
+			}
+
 		case "analyticsTags",
 			"restrictSearchableAttributes",
 			"facets",
-			"facetFilters",
 			"optionalWords":
 			switch v.(type) {
 			case string, []string:

--- a/algoliasearch/check_query_test.go
+++ b/algoliasearch/check_query_test.go
@@ -1,0 +1,18 @@
+package algoliasearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckQuery(t *testing.T) {
+	for _, m := range []Map{
+		Map{"facetFilters": "filter"},
+		Map{"facetFilters": []string{"f1", "f2"}},
+		Map{"facetFilters": [][]string{[]string{"f1", "f2"}, []string{"f3"}}},
+		Map{"facetFilters": []interface{}{[]string{"f1", "f2"}, "f3"}},
+	} {
+		require.NoError(t, checkQuery(m), "should accept the following query parameter: %#v", m)
+	}
+}


### PR DESCRIPTION
Thanks to one customer report, we discovered that the documentation was
wrong regarding the way to set the `facetFilters` parameter. This commit
adds the support for other types (namely `[][]string` and
`[]interface{}`), so that all the following calls are now legit in Go:

```go
// category:Book
"facetFilters": "category:Book"

// category:Book AND author:J.K. Rowling
"facetFilters": []string{
	"category:Book",
	"author:J.K. Rowling",
}

// (category:Book OR category:Movie) AND (author:J.K. Rowling OR author:Stephen King)
"facetFilters": [][]string{
	[]string{"category:Book", "category:Movie"},
	[]string{"author:J.K. Rowling", "author:Stephen King"},
}

// (category:Book OR category:Movie) AND author:J.K. Rowling
"facetFilters": []interface{}{
	[]string{"category:Book", "category:Movie"},
	"author:J.K. Rowling",
}
```