### PR TITLE
changed: Ensure that after a index.move, the internal name of the index is correctly updated as well

### DIFF
--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -406,7 +406,11 @@ func (i *index) Move(name string) (UpdateTaskRes, error) {
 }
 
 func (i *index) MoveWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error) {
-	return i.operation(name, "move", nil, opts)
+	res, err := i.operation(name, "move", nil, opts)
+	if err == nil {
+		i.name = name
+	}
+	return res, err
 }
 
 func (i *index) operation(dst, op string, scopes []string, opts *RequestOptions) (res UpdateTaskRes, err error) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | N/A
| Need Doc update   | no