### PR TITLE
changed: Deprecate Index.Move method in favor of Index.MoveTo

### DIFF
--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -82,13 +82,13 @@ type Client interface {
 
 	// MoveIndex renames the index named `source` as `destination`.
 	//
-	// Deprecated: Use Index.Move instead.
+	// Deprecated: Use Index.MoveTo instead.
 	MoveIndex(source, destination string) (UpdateTaskRes, error)
 
 	// MoveIndexWithRequestOptions is the same as MoveIndex but it also accepts
 	// extra RequestOptions.
 	//
-	// Deprecated: Use Index.MoveWithRequestOptions instead.
+	// Deprecated: Use Index.MoveToWithRequestOptions instead.
 	MoveIndexWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// CopyIndex duplicates the index named `source` as `destination`.
@@ -541,11 +541,22 @@ type Index interface {
 	ScopedCopyWithRequestOptions(name string, scopes []string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// Move renames the index into `name`.
+	//
+	// Deprecated: Use MoveTo instead.
 	Move(name string) (UpdateTaskRes, error)
 
 	// MoveWithRequestOptions is the same as Move but it also accepts extra
 	// RequestOptions.
+	//
+	// Deprecated: Use MoveToWithRequestOptions instead.
 	MoveWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error)
+
+	// MoveTo renames the index into `name`.
+	MoveTo(name string) (UpdateTaskRes, error)
+
+	// MoveToWithRequestOptions is the same as MoveTo but it also accepts extra
+	// RequestOptions.
+	MoveToWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// GetStatus returns the status of a task given its ID `taskID`.
 	GetStatus(taskID int) (res TaskStatusRes, err error)

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -402,10 +402,18 @@ func (i *index) ScopedCopyWithRequestOptions(name string, scopes []string, opts 
 }
 
 func (i *index) Move(name string) (UpdateTaskRes, error) {
-	return i.MoveWithRequestOptions(name, nil)
+	return i.MoveTo(name)
 }
 
 func (i *index) MoveWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error) {
+	return i.MoveToWithRequestOptions(name, opts)
+}
+
+func (i *index) MoveTo(name string) (UpdateTaskRes, error) {
+	return i.MoveToWithRequestOptions(name, nil)
+}
+
+func (i *index) MoveToWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error) {
 	return i.operation(name, "move", nil, opts)
 }
 

--- a/algoliasearch/index_test.go
+++ b/algoliasearch/index_test.go
@@ -83,10 +83,10 @@ func TestIndexOperations(t *testing.T) {
 		waitTask(t, i, res.TaskID)
 	}
 
-	t.Log("TestIndexOperations: Test Move")
+	t.Log("TestIndexOperations: Test MoveTo")
 	i = c.InitIndex("TestIndexOperations_copy")
 	{
-		res, err := i.Move("TestIndexOperations_move")
+		res, err := i.MoveTo("TestIndexOperations_moveTo")
 		if err != nil {
 			t.Fatalf("TestIndexOperations: Cannot move the index: %s", err)
 		}
@@ -95,7 +95,7 @@ func TestIndexOperations(t *testing.T) {
 	}
 
 	t.Log("TestIndexOperations: Test Clear")
-	i = c.InitIndex("TestIndexOperations_move")
+	i = c.InitIndex("TestIndexOperations_moveTo")
 	{
 		res, err := i.Clear()
 		if err != nil {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | N/A
| Need Doc update   | yes


## Describe your change

changed: Deprecate Index.Move method in favor of Index.MoveTo

## What problem is this fixing?

N/A
