### PR TITLE
Offsite changes

### DIFF
--- a/algoliasearch/account_client.go
+++ b/algoliasearch/account_client.go
@@ -1,0 +1,135 @@
+package algoliasearch
+
+import "fmt"
+
+type accountClient struct{}
+
+func NewAccountClient() AccountClient {
+	return &accountClient{}
+}
+
+func (a *accountClient) CopyIndex(src, dst Index) ([]int, error) {
+	return a.CopyIndexWithRequestOptions(src, dst, nil)
+}
+
+func (a *accountClient) CopyIndexWithRequestOptions(src, dst Index, opts *RequestOptions) ([]int, error) {
+	if src.GetAppID() == dst.GetAppID() {
+		return nil, SameAppIDErr
+	}
+
+	if _, err := dst.GetSettingsWithRequestOptions(opts); err == nil {
+		return nil, IndexAlreadyExistsErr
+	}
+
+	var taskIDs []int
+
+	// Copy synonyms
+	{
+		it := NewSynonymIterator(src)
+
+		var synonyms []Synonym
+
+		for {
+			synonym, err := it.Next()
+			if err != nil {
+				if err == NoMoreSynonymsErr {
+					break
+				} else {
+					return nil, fmt.Errorf("error while iterating source index synonyms: %v", err)
+				}
+			}
+			synonyms = append(synonyms, *synonym)
+		}
+
+		if synonyms != nil {
+			res, err := dst.ReplaceAllSynonymsWithRequestOptions(synonyms, opts)
+			if err != nil {
+				return nil, fmt.Errorf("error while replacing destination index synonyms: %v", err)
+			}
+			taskIDs = append(taskIDs, res.TaskID)
+		}
+	}
+
+	// Copy rules
+	{
+		it := NewRuleIterator(src)
+
+		var rules []Rule
+
+		for {
+			rule, err := it.Next()
+			if err != nil {
+				if err == NoMoreRulesErr {
+					break
+				} else {
+					return nil, fmt.Errorf("error while iterating source index rules: %v", err)
+				}
+			}
+			rules = append(rules, *rule)
+		}
+		if rules != nil {
+			res, err := dst.ReplaceAllRulesWithRequestOptions(rules, opts)
+			if err != nil {
+				return nil, fmt.Errorf("error while replacing destination index rules: %v", err)
+			}
+			taskIDs = append(taskIDs, res.TaskID)
+		}
+	}
+
+	// Copy settings
+	{
+		settings, err := src.GetSettingsWithRequestOptions(opts)
+		if err != nil {
+			return nil, fmt.Errorf("cannot retrieve source index settings: %v", err)
+		}
+
+		res, err := dst.SetSettingsWithRequestOptions(settings.ToMap(), opts)
+		if err != nil {
+			return nil, fmt.Errorf("cannot set destination index settings: %v", err)
+		}
+		taskIDs = append(taskIDs, res.TaskID)
+
+	}
+
+	// Copy objects
+	{
+		it, err := src.BrowseAllWithRequestOptions(nil, opts)
+		if err != nil {
+			return nil, fmt.Errorf("cannot browse source index objects: %v", err)
+		}
+
+		var objects []Object
+		batchSize := 1000
+
+		for {
+			res, err := it.Next()
+			if err != nil {
+				if err == NoMoreHitsErr {
+					break
+				} else {
+					return nil, fmt.Errorf("error while iterating source index objects: %v", err)
+				}
+			}
+			objects = append(objects, Object(res))
+
+			if len(objects) >= batchSize {
+				res, err := dst.AddObjectsWithRequestOptions(objects, opts)
+				if err != nil {
+					return nil, fmt.Errorf("error while saving batch of objects: %v", err)
+				}
+				taskIDs = append(taskIDs, res.TaskID)
+				objects = []Object{}
+			}
+		}
+
+		// Send the last batch
+		res, err := dst.AddObjectsWithRequestOptions(objects, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error while saving batch of objects: %v", err)
+		}
+		taskIDs = append(taskIDs, res.TaskID)
+		objects = []Object{}
+	}
+
+	return taskIDs, nil
+}

--- a/algoliasearch/account_client_test.go
+++ b/algoliasearch/account_client_test.go
@@ -1,0 +1,93 @@
+package algoliasearch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountClient(t *testing.T) {
+	client1, index1 := initClientAndIndex(t, "TestAccountClient")
+
+	index2 := client1.InitIndex("go-TestAccountClient")
+	{
+		account := NewAccountClient()
+		_, err := account.CopyIndex(index1, index2)
+		require.Equal(t, SameAppIDErr, err)
+	}
+
+	client2 := initClient2(t)
+	index2 = client2.InitIndex("go-TestAccountClient")
+
+	{
+		_, err := index2.Delete()
+		require.NoError(t, err)
+	}
+
+	var taskIDs []int
+
+	{
+		res, err := index1.AddObject(Object{"objectID": "one"})
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	{
+		res, err := index1.SaveRule(Rule{
+			ObjectID:  "one",
+			Condition: NewSimpleRuleCondition(Contains, "pattern"),
+			Consequence: RuleConsequence{
+				Params: Map{
+					"query": Map{
+						"edits": []Edit{DeleteEdit("pattern")},
+					},
+				},
+			},
+		}, false)
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	{
+		res, err := index1.SaveSynonym(NewSynonym("one", []string{"one", "two"}), false)
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	{
+		res, err := index1.SetSettings(Map{"searchableAttributes": []string{"objectID"}})
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	waitTasksAsync(t, index1, taskIDs)
+	taskIDs = []int{}
+
+	{
+		account := NewAccountClient()
+		taskIDs, err := account.CopyIndex(index1, index2)
+		require.NoError(t, err)
+		waitTasksAsync(t, index2, taskIDs)
+	}
+
+	{
+		_, err := index2.GetObject("one", nil)
+		require.NoError(t, err)
+
+		_, err = index2.GetRule("one")
+		require.NoError(t, err)
+
+		_, err = index2.GetSynonym("one")
+		require.NoError(t, err)
+
+		settings, err := index2.GetSettings()
+		require.NoError(t, err)
+		require.Equal(t, []string{"objectID"}, settings.SearchableAttributes)
+	}
+
+	{
+		account := NewAccountClient()
+		_, err := account.CopyIndex(index1, index2)
+		require.Equal(t, IndexAlreadyExistsErr, err)
+	}
+}

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -816,6 +816,27 @@ type Index interface {
 	// SearchRulesWithRequestOptions is the same as SearchRules but it also
 	// accepts extra RequestOptions.
 	SearchRulesWithRequestOptions(params Map, opts *RequestOptions) (SearchRulesRes, error)
+
+	// ReplaceAllSynonyms replace all the synonyms of the current index with the given ones.
+	ReplaceAllSynonyms(synonyms []Synonym) (res UpdateTaskRes, err error)
+
+	// ReplaceAllSynonymsWithRequestOptions is the same as ReplaceAllSynonyms but it also
+	// accepts extra RequestOptions.
+	ReplaceAllSynonymsWithRequestOptions(synonyms []Synonym, opts *RequestOptions) (res UpdateTaskRes, err error)
+
+	// ReplaceAllRules replace all the rules of the current index with the given ones.
+	ReplaceAllRules(rules []Rule) (res BatchRulesRes, err error)
+
+	// ReplaceAllRulesWithRequestOptions is the same as ReplaceAllRules but it also
+	// accepts extra RequestOptions.
+	ReplaceAllRulesWithRequestOptions(rules []Rule, opts *RequestOptions) (res BatchRulesRes, err error)
+
+	// ReplaceAllObjects replace all the objects of the current index with the given ones.
+	ReplaceAllObjects(objects []Object) error
+
+	// ReplaceAllObjectsWithRequestOptions is the same as ReplaceAllObjects but it also
+	// accepts extra RequestOptions.
+	ReplaceAllObjectsWithRequestOptions(objects []Object, opts *RequestOptions) error
 }
 
 // IndexIterator is used by the BrowseAll functions to iterate over all the

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -9,6 +9,9 @@ import (
 // allows manipulations over the indexes of the application as well as network
 // related parameters.
 type Client interface {
+	// GetAppID returns the Algolia application ID to which the client is linked to.
+	GetAppID() string
+
 	// SetExtraHeader allows to set custom headers while reaching out to
 	// Algolia servers.
 	SetExtraHeader(key, value string)
@@ -306,6 +309,9 @@ type Client interface {
 
 // Index is a representation used to manipulate an Algolia index.
 type Index interface {
+	// GetAppID returns the Algolia application ID to which the index is linked to.
+	GetAppID() string
+
 	// Delete removes the Algolia index.
 	Delete() (res DeleteTaskRes, err error)
 

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -526,36 +526,48 @@ type Index interface {
 	BatchWithRequestOptions(operations []BatchOperation, opts *RequestOptions) (res BatchRes, err error)
 
 	// Copy copies the index into a new one called `name`.
+	//
+	// Deprecated: Use Client.CopyIndex instead.
 	Copy(name string) (UpdateTaskRes, error)
 
 	// CopyWithRequestOptions is the same as Copy but it also accepts extra
 	// RequestOptions.
+	//
+	// Deprecated: Use Client.CopyIndexWithRequestOptions instead.
 	CopyWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// ScopedCopy copies the index into a new one called `name`, according to
 	// the given scopes.
+	//
+	// Deprecated: Use Client.ScopedCopyIndex instead.
 	ScopedCopy(name string, scopes []string) (UpdateTaskRes, error)
 
 	// ScopedCopyWithRequestOptions is the same as ScopedCopy but it also
 	// accepts extra RequestOptions.
+	//
+	// Deprecated: Use Client.ScopedCopyIndexWithRequestOptions instead.
 	ScopedCopyWithRequestOptions(name string, scopes []string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// Move renames the index into `name`.
 	//
-	// Deprecated: Use MoveTo instead.
+	// Deprecated: Use Client.MoveIndex instead.
 	Move(name string) (UpdateTaskRes, error)
 
 	// MoveWithRequestOptions is the same as Move but it also accepts extra
 	// RequestOptions.
 	//
-	// Deprecated: Use MoveToWithRequestOptions instead.
+	// Deprecated: Use Client.MoveIndexWithRequestOptions instead.
 	MoveWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// MoveTo renames the index into `name`.
+	//
+	// Deprecated: Use Client.MoveIndex instead.
 	MoveTo(name string) (UpdateTaskRes, error)
 
 	// MoveToWithRequestOptions is the same as MoveTo but it also accepts extra
 	// RequestOptions.
+	//
+	// Deprecated: Use Client.MoveIndexWithRequestOptions instead.
 	MoveToWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// GetStatus returns the status of a task given its ID `taskID`.

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -883,3 +883,14 @@ type Analytics interface {
 	// goes wrong or if the task did not succeed, a non-nil error is returned.
 	WaitTask(task ABTestTaskRes) (err error)
 }
+
+// AccountClient is responsible for handling cross-application operations.
+type AccountClient interface {
+	// CopyIndex copies the content of the entire source index to the destination index. Indices from the same
+	// application cannot be copied. To do so, use Client.CopyIndex instead.
+	CopyIndex(src, dst Index) (taskIDs []int, err error)
+
+	// CopyIndexWithRequestOptions is the same as CopyIndex but it also
+	// accepts extra RequestOptions.
+	CopyIndexWithRequestOptions(src, dst Index, opts *RequestOptions) (taskIDs []int, err error)
+}

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -273,6 +273,27 @@ type Client interface {
 	// GetStatusWithRequestOptions is the same as GetStatus but it also accepts
 	// extra RequestOptions.
 	GetStatusWithRequestOptions(indexName string, taskID int, opts *RequestOptions) (res TaskStatusRes, err error)
+
+	// CopySettings copies the settings from the source index to the destination index.
+	CopySettings(source, destination string) (UpdateTaskRes, error)
+
+	// CopySettingsWithRequestOptions is the same as CopySettings but it also accepts
+	// extra RequestOptions.
+	CopySettingsWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error)
+
+	// CopySynonyms copies the synonyms from the source index to the destination index.
+	CopySynonyms(source, destination string) (UpdateTaskRes, error)
+
+	// CopySynonymsWithRequestOptions is the same as CopySynonyms but it also accepts
+	// extra RequestOptions.
+	CopySynonymsWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error)
+
+	// CopyRules copies the rules from the source index to the destination index.
+	CopyRules(source, destination string) (UpdateTaskRes, error)
+
+	// CopyRulesWithRequestOptions is the same as CopyRulesWith but it also accepts
+	// extra RequestOptions.
+	CopyRulesWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error)
 }
 
 // Index is a representation used to manipulate an Algolia index.

--- a/algoliasearch/algoliasearch.go
+++ b/algoliasearch/algoliasearch.go
@@ -107,17 +107,25 @@ type Client interface {
 	ScopedCopyIndexWithRequestOptions(source, destination string, scopes []string, opts *RequestOptions) (UpdateTaskRes, error)
 
 	// DeleteIndex removes the `name` Algolia index.
+	//
+	// Deprecated: Use Index.Delete instead.
 	DeleteIndex(name string) (res DeleteTaskRes, err error)
 
 	// DeleteIndexWithRequestOptions is the same as DeleteIndex but it also
 	// accepts extra RequestOptions.
+	//
+	// Deprecated: Use Index.DeleteWithRequestOptions instead.
 	DeleteIndexWithRequestOptions(name string, opts *RequestOptions) (res DeleteTaskRes, err error)
 
 	// ClearIndex removes every record from the `name` Algolia index.
+	//
+	// Deprecated: Use Index.Clear instead.
 	ClearIndex(name string) (res UpdateTaskRes, err error)
 
 	// ClearIndexWithRequestOptions is the same as ClearIndex but it also
 	// accepts extra RequestOptions.
+	//
+	// Deprecated: Use Index.ClearWithRequestOptions instead.
 	ClearIndexWithRequestOptions(name string, opts *RequestOptions) (res UpdateTaskRes, err error)
 
 	// AddUserKey creates a new API key from the supplied `ACL` and the

--- a/algoliasearch/check_rule.go
+++ b/algoliasearch/check_rule.go
@@ -30,10 +30,10 @@ func checkRules(rules []Rule) error {
 
 			case "query":
 				switch v.(type) {
-				case string, QueryIncrementalEdit, Map:
+				case string, QueryIncrementalEdit, Edit, Map, map[string]interface{}:
 					// OK
 				default:
-					return invalidType(k, "string or QueryIncrementalEdit or Map")
+					return invalidType(k, "string, QueryIncrementalEdit, Edit or Map")
 				}
 
 			case "automaticFacetFilters",

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -10,6 +10,7 @@ import (
 )
 
 type client struct {
+	appID     string
 	transport *Transport
 }
 
@@ -17,6 +18,7 @@ type client struct {
 // `apiKey`. Default hosts are used for the transport layer.
 func NewClient(appID, apiKey string) Client {
 	return &client{
+		appID:     appID,
 		transport: NewTransport(appID, apiKey),
 	}
 }
@@ -26,8 +28,13 @@ func NewClient(appID, apiKey string) Client {
 // `hosts`.
 func NewClientWithHosts(appID, apiKey string, hosts []string) Client {
 	return &client{
+		appID:     appID,
 		transport: NewTransportWithHosts(appID, apiKey, hosts),
 	}
+}
+
+func (c *client) GetAppID() string {
+	return c.appID
 }
 
 func (c *client) SetExtraHeader(key, value string) {

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -410,6 +410,33 @@ func (c *client) GetStatusWithRequestOptions(indexName string, taskID int, opts 
 	return
 }
 
+func (c *client) CopySettings(source, destination string) (UpdateTaskRes, error) {
+	return c.CopySettingsWithRequestOptions(source, destination, nil)
+}
+
+func (c *client) CopySettingsWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error) {
+	return c.ScopedCopyIndexWithRequestOptions(source, destination, []string{"settings"}, opts)
+}
+
+func (c *client) CopySynonyms(source, destination string) (UpdateTaskRes, error) {
+	return c.CopySynonymsWithRequestOptions(source, destination, nil)
+}
+
+func (c *client) CopySynonymsWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error) {
+	return c.ScopedCopyIndexWithRequestOptions(source, destination, []string{"synonyms"}, opts)
+}
+
+// CopySettings copies the rules from the source index to the destination index.
+func (c *client) CopyRules(source, destination string) (UpdateTaskRes, error) {
+	return c.CopyRulesWithRequestOptions(source, destination, nil)
+}
+
+// CopyRulesWithRequestOptions is the same as CopyRulesWith but it also accepts
+// extra RequestOptions.
+func (c *client) CopyRulesWithRequestOptions(source, destination string, opts *RequestOptions) (UpdateTaskRes, error) {
+	return c.ScopedCopyIndexWithRequestOptions(source, destination, []string{"rules"}, opts)
+}
+
 func (c *client) request(res interface{}, method, path string, body interface{}, typeCall int, opts *RequestOptions) error {
 	r, err := c.transport.request(method, path, body, typeCall, opts)
 	if err != nil {

--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -138,7 +138,6 @@ func (c *client) operation(src, dst, op string, scopes []string, opts *RequestOp
 	return
 }
 
-
 func (c *client) DeleteIndex(name string) (res DeleteTaskRes, err error) {
 	return c.DeleteIndexWithRequestOptions(name, nil)
 }

--- a/algoliasearch/errors.go
+++ b/algoliasearch/errors.go
@@ -10,6 +10,8 @@ var (
 	NoMoreSynonymsErr           error = errors.New("No more synonyms")
 	NoMoreRulesErr              error = errors.New("No more rules")
 	ExhaustionOfTryableHostsErr error = errors.New("All hosts have been contacted unsuccessfully")
+	SameAppIDErr                error = errors.New("Indices cannot target the same application ID. Please use Client.CopyIndex for same-app index copy instead.")
+	IndexAlreadyExistsErr       error = errors.New("Destination index already exists. Please delete it first as the CopyIndex cannot hold the responsibility of modifying the destination index.")
 )
 
 // NetError is used internally to differente regular error from errors

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type index struct {
@@ -752,5 +753,96 @@ func (i *index) SearchRulesWithRequestOptions(params Map, opts *RequestOptions) 
 
 	path := i.route + "/rules/search"
 	err = i.client.request(&res, "POST", path, params, read, opts)
+	return
+}
+
+// ReplaceAllSynonyms replace all the synonyms of the current index with the given ones.
+func (i *index) ReplaceAllSynonyms(synonyms []Synonym) (res UpdateTaskRes, err error) {
+	return i.ReplaceAllSynonymsWithRequestOptions(synonyms, nil)
+}
+
+// ReplaceAllSynonymsWithRequestOptions is the same as ReplaceAllSynonyms but it also
+// accepts extra RequestOptions.
+func (i *index) ReplaceAllSynonymsWithRequestOptions(synonyms []Synonym, opts *RequestOptions) (res UpdateTaskRes, err error) {
+	return i.BatchSynonymsWithRequestOptions(synonyms, true, false, opts)
+}
+
+// ReplaceAllRules replace all the rules of the current index with the given ones.
+func (i *index) ReplaceAllRules(rules []Rule) (res BatchRulesRes, err error) {
+	return i.ReplaceAllRulesWithRequestOptions(rules, nil)
+}
+
+// ReplaceAllRulesWithRequestOptions is the same as ReplaceAllRules but it also
+// accepts extra RequestOptions.
+func (i *index) ReplaceAllRulesWithRequestOptions(rules []Rule, opts *RequestOptions) (res BatchRulesRes, err error) {
+	return i.BatchRulesWithRequestOptions(rules, false, true, opts)
+}
+
+// ReplaceAllObjects replace all the objects of the current index with the given ones.
+func (i *index) ReplaceAllObjects(objects []Object) error {
+	return i.ReplaceAllObjectsWithRequestOptions(objects, nil)
+}
+
+// ReplaceAllObjectsWithRequestOptions is the same as ReplaceAllObjects but it also
+// accepts extra RequestOptions.
+func (i *index) ReplaceAllObjectsWithRequestOptions(objects []Object, opts *RequestOptions) (err error) {
+	tmpIndexName := fmt.Sprintf("%s_tmp_%d", i.name, time.Now().Nanosecond())
+
+	defer func() {
+		if err != nil {
+			i.client.DeleteIndexWithRequestOptions(tmpIndexName, opts)
+		}
+	}()
+
+	var taskIDs []int
+
+	// Copy settings/synonyms/rules to the temporary index
+	{
+		var res UpdateTaskRes
+		res, err = i.client.ScopedCopyIndexWithRequestOptions(i.name, tmpIndexName, []string{"settings", "synonyms", "rules"}, opts)
+		if err != nil {
+			return
+		}
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	tmpIndex := i.client.InitIndex(tmpIndexName)
+
+	// Copy objects to the temporary index
+	{
+		batchSize := 1000
+
+		for i := 0; i < len(objects); i += batchSize {
+			j := i + batchSize
+			if j > len(objects) {
+				j = len(objects)
+			}
+			var res BatchRes
+			res, err = tmpIndex.AddObjectsWithRequestOptions(objects[i:j], opts)
+			if err != nil {
+				return
+			}
+			taskIDs = append(taskIDs, res.TaskID)
+		}
+	}
+
+	// Wait for all the tasks to finish before performing the move of the temporary index to the final one.
+	for _, taskID := range taskIDs {
+		err = tmpIndex.WaitTaskWithRequestOptions(taskID, opts)
+		if err != nil {
+			return
+		}
+	}
+
+	// Perform the move operation
+	{
+		var res UpdateTaskRes
+		res, err = i.client.MoveIndexWithRequestOptions(tmpIndexName, i.name, opts)
+		if err != nil {
+			return
+		}
+		tmpIndex.WaitTaskWithRequestOptions(res.TaskID, opts)
+	}
+
 	return
 }

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -24,6 +24,10 @@ func NewIndex(name string, client *client) Index {
 	}
 }
 
+func (i *index) GetAppID() string {
+	return i.client.GetAppID()
+}
+
 func (i *index) Delete() (res DeleteTaskRes, err error) {
 	return i.DeleteWithRequestOptions(nil)
 }

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -398,7 +398,7 @@ func (i *index) ScopedCopy(name string, scopes []string) (UpdateTaskRes, error) 
 }
 
 func (i *index) ScopedCopyWithRequestOptions(name string, scopes []string, opts *RequestOptions) (UpdateTaskRes, error) {
-	return i.operation(name, "copy", scopes, opts)
+	return i.client.ScopedCopyIndexWithRequestOptions(i.name, name, scopes, opts)
 }
 
 func (i *index) Move(name string) (UpdateTaskRes, error) {
@@ -414,23 +414,7 @@ func (i *index) MoveTo(name string) (UpdateTaskRes, error) {
 }
 
 func (i *index) MoveToWithRequestOptions(name string, opts *RequestOptions) (UpdateTaskRes, error) {
-	return i.operation(name, "move", nil, opts)
-}
-
-func (i *index) operation(dst, op string, scopes []string, opts *RequestOptions) (res UpdateTaskRes, err error) {
-	if err = checkScopes(scopes); err != nil {
-		return
-	}
-
-	o := IndexOperation{
-		Destination: dst,
-		Operation:   op,
-		Scopes:      scopes,
-	}
-
-	path := i.route + "/operation"
-	err = i.client.request(&res, "POST", path, o, write, opts)
-	return
+	return i.client.MoveIndexWithRequestOptions(i.name, name, opts)
 }
 
 func (i *index) GetStatus(taskID int) (res TaskStatusRes, err error) {

--- a/algoliasearch/index_test.go
+++ b/algoliasearch/index_test.go
@@ -1750,3 +1750,93 @@ func TestBrowseAll(t *testing.T) {
 		require.Equal(t, 3501, count, "should browse all the records")
 	}
 }
+
+func TestReplaceAll(t *testing.T) {
+	_, index := initClientAndIndex(t, "TestReplaceAll")
+
+	var taskIDs []int
+
+	{
+		res, err := index.AddObject(Object{"objectID": "one"})
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	{
+		res, err := index.SaveRule(Rule{
+			ObjectID:  "one",
+			Condition: NewSimpleRuleCondition(Contains, "pattern"),
+			Consequence: RuleConsequence{
+				Params: Map{
+					"query": Map{
+						"edits": []Edit{DeleteEdit("pattern")},
+					},
+				},
+			},
+		}, false)
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	{
+		res, err := index.SaveSynonym(NewSynonym("one", []string{"one", "two"}), false)
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	waitTasksAsync(t, index, taskIDs)
+	taskIDs = []int{}
+
+	{
+		err := index.ReplaceAllObjects([]Object{{"objectID": "two"}})
+		require.NoError(t, err)
+	}
+
+	{
+		res, err := index.ReplaceAllRules([]Rule{
+			{
+				ObjectID:  "two",
+				Condition: NewSimpleRuleCondition(Contains, "pattern"),
+				Consequence: RuleConsequence{
+					Params: Map{
+						"query": Map{
+							"edits": []Edit{DeleteEdit("pattern")},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	{
+		res, err := index.ReplaceAllSynonyms([]Synonym{
+			NewSynonym("two", []string{"one", "two"}),
+		})
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, res.TaskID)
+	}
+
+	waitTasksAsync(t, index, taskIDs)
+
+	{
+		_, err := index.GetObject("one", nil)
+		require.Error(t, err)
+
+		_, err = index.GetObject("two", nil)
+		require.NoError(t, err)
+
+		_, err = index.GetRule("one")
+		require.Error(t, err)
+
+		_, err = index.GetRule("two")
+		require.NoError(t, err)
+
+		_, err = index.GetSynonym("one")
+		require.Error(t, err)
+
+		_, err = index.GetSynonym("two")
+		require.NoError(t, err)
+	}
+}

--- a/algoliasearch/secured_api_key_test.go
+++ b/algoliasearch/secured_api_key_test.go
@@ -3,13 +3,18 @@ package algoliasearch
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateSecuredAPIKey_Generation(t *testing.T) {
 	t.Parallel()
-	apiKey := os.Getenv("ALGOLIA_API_KEY")
+
+	apiKey := os.Getenv("ALGOLIA_SEARCH_KEY_1")
 	if apiKey == "" {
-		t.Fatal("TestGenerateSecuredAPIKey_Generation: Missing ALGOLIA_API_KEY")
+		t.Fatal("TestGenerateSecuredAPIKey_Generation: Missing ALGOLIA_SEARCH_KEY_1")
 	}
 
 	t.Log("TestGenerateSecuredAPIKey_Generation: Tests invalid key generations")
@@ -26,12 +31,7 @@ func TestGenerateSecuredAPIKey_Generation(t *testing.T) {
 
 		for _, c := range cases {
 			_, err := GenerateSecuredAPIKey(apiKey, c.params)
-			if err == nil || err.Error() != c.expectedErr.Error() {
-				t.Errorf("TestGenerateSecuredAPIKey_Generation: Calling GenerateSecuredAPIKey(%#v)\nexpected error:  \"%s\"\nbut got instead: \"%s\"",
-					c.params,
-					c.expectedErr,
-					err)
-			}
+			require.Equal(t, c.expectedErr, err, "wrong error when generating secured API key for %#v", c.params)
 		}
 	}
 
@@ -41,24 +41,16 @@ func TestGenerateSecuredAPIKey_Generation(t *testing.T) {
 			params      Map
 			expectedKey string
 		}{
-			{Map{"userToken": "user42"}, "NTc5YjBkMTgwYjdkMzBlYzllYzY5MmY3OGRmOGQzMWU3ZWU0ZTI2ZmY4MGQ0ZTZhMWZlNzJiMzllMjg5YzhmZnVzZXJUb2tlbj11c2VyNDI="},
-			{Map{"restrictIndices": "myIndex"}, "ZGQ5NjRjYTdmOWRkYzYwMjBkNWQ4ZGQ3MmZlY2RkOTYyZjIxM2FjNDBhMjBhYzhhNDFiYWI4NDE4ZGJiOTgxYXJlc3RyaWN0SW5kaWNlcz1teUluZGV4"},
-			{Map{"restrictSources": ""}, "NmNjYzQ0MzI0MmU3OTg1NDJiZDYyNTIwZjE2OWMwYjU1MjQ0ZmFhNDdmNzdjNDg1MGYxYmY1YWJjNWZkOTU2OHJlc3RyaWN0U291cmNlcz0="},
-			{Map{"validUntil": 1481901339150}, "NDZiMWNlNDMyMzEzNTRkZjFiYmMyYjE2ZWFmNzVjOWE5MjkzNTllMTgxZjM3NDI1OWNiZjAyOGZjMTc0NzU3MXZhbGlkVW50aWw9MTQ4MTkwMTMzOTE1MA=="},
+			{Map{"userToken": "user42"}, "ZDhjZmNmMmMzY2Y4MWY1NjBhMDg0NjNkYzMxYTA2ZTM5YTIyY2JkZDVmMDAwMDNhMDQ2ZGUyYjZkMjc0ZjdmOXVzZXJUb2tlbj11c2VyNDI="},
+			{Map{"restrictIndices": "myIndex"}, "OWEwZGMwZGRjYTg3YzY2NzA2MTA2YTQ2YTIyN2Q1MDk4N2NlY2Y5OTE4ZWU4Y2U5NTkyYWQ2MWI1ZTQ3NjMwOHJlc3RyaWN0SW5kaWNlcz1teUluZGV4"},
+			{Map{"restrictSources": ""}, "NWMyZjI2ZWNmMTZiY2YyZTNlZmQzZTFjZTg0MGE1OTU2ZjE1NWE2ZGQ2OWI4OTRjMmVhMzJhNDkyNzQ4MjQwN3Jlc3RyaWN0U291cmNlcz0="},
+			{Map{"validUntil": 1481901339150}, "NDFiNDFkMzNkNmQ5NDZhZTU2MmIxMzVmODg1YWZkNWI2ODIzMWE5NDIyZGJlNDRlNjM3OWMwOGJhY2RmY2I0NXZhbGlkVW50aWw9MTQ4MTkwMTMzOTE1MA=="},
 		}
 
 		for _, c := range cases {
 			generatedKey, err := GenerateSecuredAPIKey(apiKey, c.params)
-			if err != nil {
-				t.Errorf("TestGenerateSecuredAPIKey_Generation: Key with params %#v should have been generated withouth error but got: %s", c.params, err)
-			}
-
-			if generatedKey != c.expectedKey {
-				t.Errorf("TestGenerateSecuredAPIKey_Generation: Key was not generated correctly for params %#v:\nexpected key:  \"%s\"\nbut got instead: \"%s\"",
-					c.params,
-					c.expectedKey,
-					generatedKey)
-			}
+			assert.NoError(t, err, "should not error while generating secured API key for %#v", c.params)
+			assert.Equal(t, c.expectedKey, generatedKey, "wrong secured API key was generated for %#v", c.params)
 		}
 	}
 }
@@ -66,26 +58,18 @@ func TestGenerateSecuredAPIKey_Generation(t *testing.T) {
 func TestGenerateSecuredAPIKey_Usage(t *testing.T) {
 	t.Parallel()
 
-	t.Log("TestGenerateSecuredAPIKey_Usage: Obtain application ID/API key from the environment")
-	appID := os.Getenv("ALGOLIA_APPLICATION_ID")
-	if appID == "" {
-		t.Fatalf("TestGenerateSecuredAPIKey_Usage: Cannot retrieve application ID from environment")
-	}
-	apiKey := os.Getenv("ALGOLIA_SEARCH_KEY")
-	if apiKey == "" {
-		t.Fatal("TestGenerateSecuredAPIKey_Usage: Missing ALGOLIA_SEARCH_KEY")
-	}
+	appID := os.Getenv("ALGOLIA_APPLICATION_ID_1")
+	require.NotEmpty(t, appID)
 
-	t.Log("TestGenerateSecuredAPIKey_Usage: Generate secured API key")
+	apiKey := os.Getenv("ALGOLIA_SEARCH_KEY_1")
+	require.NotEmpty(t, apiKey)
+
 	params := Map{
 		"restrictIndices": "TestGenerateSecuredAPIKey_Usage_1,TestGenerateSecuredAPIKey_Usage_2",
 	}
 	key, err := GenerateSecuredAPIKey(apiKey, params)
-	if err != nil {
-		t.Fatalf("TestGenerateSecuredAPIKey_Usage: should generate key without error")
-	}
+	require.NoError(t, err)
 
-	t.Log("TestGenerateSecuredAPIKey_Usage: Check if key correctly restrict accesse to indices")
 	client := initClient(t)
 	restrictedClient := NewClient(appID, key)
 
@@ -102,11 +86,10 @@ func TestGenerateSecuredAPIKey_Usage(t *testing.T) {
 
 		i = restrictedClient.InitIndex(c.indexName)
 		_, err := i.Search("", nil)
-		if c.isAuthorized && err != nil {
-			t.Fatalf("TestGenerateSecuredAPIKey_Usage: index %s should be searchable with restricted API key", c.indexName)
-		}
-		if !c.isAuthorized && err == nil {
-			t.Fatalf("TestGenerateSecuredAPIKey_Usage: index %s should not be searchable with restricted API key", c.indexName)
+		if c.isAuthorized {
+			assert.NoError(t, err, "should be able to search in index %q", c.indexName)
+		} else {
+			assert.Error(t, err, "should be able to search in index %q", c.indexName)
 		}
 	}
 }

--- a/algoliasearch/testing_test.go
+++ b/algoliasearch/testing_test.go
@@ -49,13 +49,26 @@ func addOneObject(t *testing.T, i Index) string {
 }
 
 // initClient instantiates a new client according to the
-// `ALGOLIA_APPLICATION_ID` and `ALGOLIA_API_KEY` environment variables.
+// `ALGOLIA_APPLICATION_ID_1` and `ALGOLIA_ADMIN_KEY_1` environment variables.
 func initClient(t *testing.T) Client {
-	appID := os.Getenv("ALGOLIA_APPLICATION_ID")
-	apiKey := os.Getenv("ALGOLIA_API_KEY")
+	appID := os.Getenv("ALGOLIA_APPLICATION_ID_1")
+	apiKey := os.Getenv("ALGOLIA_ADMIN_KEY_1")
 
 	if appID == "" || apiKey == "" {
-		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID and/or ALGOLIA_API_KEY")
+		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID_1 and/or ALGOLIA_ADMIN_KEY_1")
+	}
+
+	return NewClient(appID, apiKey)
+}
+
+// initClient instantiates a new client according to the
+// `ALGOLIA_APPLICATION_ID_2` and `ALGOLIA_ADMIN_KEY_2` environment variables.
+func initClient2(t *testing.T) Client {
+	appID := os.Getenv("ALGOLIA_APPLICATION_ID_2")
+	apiKey := os.Getenv("ALGOLIA_ADMIN_KEY_2")
+
+	if appID == "" || apiKey == "" {
+		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID_2 and/or ALGOLIA_ADMIN_KEY_2")
 	}
 
 	return NewClient(appID, apiKey)
@@ -63,25 +76,25 @@ func initClient(t *testing.T) Client {
 
 // initMCMClient is the same as initClient but read different env vars
 func initMCMClient(t *testing.T) Client {
-	appID := os.Getenv("ALGOLIA_APP_ID_MCM")
-	apiKey := os.Getenv("ALGOLIA_API_KEY_MCM")
+	appID := os.Getenv("ALGOLIA_APPLICATION_ID_MCM")
+	apiKey := os.Getenv("ALGOLIA_ADMIN_KEY_MCM")
 
 	if appID == "" || apiKey == "" {
-		t.Fatal("initClient: Missing ALGOLIA_APP_ID_MCM and/or ALGOLIA_API_KEY_MCM")
+		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID_MCM and/or ALGOLIA_ADMIN_KEY_MCM")
 	}
 
 	return NewClient(appID, apiKey)
 }
 
 // initClientWithHosts instantiates a new client according to the
-// `ALGOLIA_APPLICATION_ID` and `ALGOLIA_API_KEY` environment variables and set
+// `ALGOLIA_APPLICATION_ID_1` and `ALGOLIA_ADMIN_KEY_1` environment variables and set
 // one of the host to specifically timeout.
 func initClientWithTimeoutHosts(t *testing.T) Client {
-	appID := os.Getenv("ALGOLIA_APPLICATION_ID")
-	apiKey := os.Getenv("ALGOLIA_API_KEY")
+	appID := os.Getenv("ALGOLIA_APPLICATION_ID_1")
+	apiKey := os.Getenv("ALGOLIA_ADMIN_KEY_1")
 
 	if appID == "" || apiKey == "" {
-		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID and/or ALGOLIA_API_KEY")
+		t.Fatal("initClient: Missing ALGOLIA_APPLICATION_ID_1 and/or ALGOLIA_ADMIN_KEY_1")
 	}
 
 	return NewClientWithHosts(appID, apiKey, []string{


### PR DESCRIPTION
 * added: Implement AccountClient.CopyIndex 
 * changed: remove extra empty line 
 * changed: Use the environment variables from our Common Test Suite for testing 
 * added: Implement Index.GetAppID and Client.GetAppID methods 
 * added: Implement Index.Replace{Objects,Rules,Synonyms} 
 * deprecated: Index.{Delete,Clear} replaced by Client.{Delete,Clear}Index 
 * added: Implement Client.Copy{Settings,Synonyms,Rules} 
 * deprecated: Index.{Copy,Move} replaced by Client.{Copy,Move}Index 