### PR TITLE
fix: change AddAPIKey type from read to write

### DIFF
--- a/algoliasearch/client.go
+++ b/algoliasearch/client.go
@@ -172,7 +172,7 @@ func (c *client) AddAPIKeyWithRequestOptions(ACL []string, params Map, opts *Req
 		return
 	}
 
-	err = c.request(&res, "POST", "/1/keys/", req, read, opts)
+	err = c.request(&res, "POST", "/1/keys/", req, write, opts)
 	return
 }
 

--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -196,7 +196,7 @@ func (i *index) AddAPIKeyWithRequestOptions(ACL []string, params Map, opts *Requ
 	}
 
 	path := i.route + "/keys"
-	err = i.client.request(&res, "POST", path, req, read, opts)
+	err = i.client.request(&res, "POST", path, req, write, opts)
 	return
 }
 


### PR DESCRIPTION
This commit ensures that we avoid targeting DSNs when adding API keys.


| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no