### PR TITLE
Aa testing custom search parameters

### DIFF
--- a/algoliasearch/types_abtesting.go
+++ b/algoliasearch/types_abtesting.go
@@ -29,9 +29,10 @@ func (abTest ABTest) MarshalJSON() ([]byte, error) {
 }
 
 type Variant struct {
-	Index             string `json:"index"`
-	TrafficPercentage int    `json:"trafficPercentage"`
-	Description       string `json:"description,omitempty"`
+	Index                  string `json:"index"`
+	TrafficPercentage      int    `json:"trafficPercentage"`
+	Description            string `json:"description,omitempty"`
+	CustomSearchParameters Map    `json:"customSearchParameters,omitempty"`
 }
 
 type ABTestTaskRes struct {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

Expose the new `customSearchParameters` fields to AB test variant in order to submit AA tests. This PR doesn't include the test because the CTS is currently only implemented in the v3 branch of the client and this is where the test now lives. At the moment, adding a test for AA testing would conflict with the existing AB testing test, so I choose not to do the job twice in the two branches.