### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/algoliasearch/transport.go
+++ b/algoliasearch/transport.go
@@ -52,7 +52,7 @@ func NewTransport(appID, apiKey string) *Transport {
 	return NewTransportWithHosts(appID, apiKey, nil)
 }
 
-// NewTransport instantiates a new Transport with the specificed hosts as main
+// NewTransportWithHosts instantiates a new Transport with the specificed hosts as main
 // servers to connect to.
 func NewTransportWithHosts(appID, apiKey string, hosts []string) *Transport {
 	return &Transport{


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?