### PR TITLE
fixed: Correctly retrieve objectIDs using GetObjects

### DIFF
--- a/algoliasearch/index.go
+++ b/algoliasearch/index.go
@@ -77,7 +77,7 @@ func (i *index) getObjects(objectIDs, attributesToRetrieve []string, opts *Reque
 	for j, id := range objectIDs {
 		requests[j] = map[string]string{
 			"indexName": i.name,
-			"objectID":  url.QueryEscape(id),
+			"objectID":  id,
 		}
 		if attributesToRetrieve != nil {
 			requests[j]["attributesToRetrieve"] = attrs


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #456 
| Need Doc update   | no


## Describe your change

Do not URL encode objectIDs passed via the body of `GetObjects` requests.

## What problem is this fixing?

Otherwise, objects contained expendable characters cannot be retrieved.