### PR TITLE
fix(response): ABTestVariantID is an int not a string

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -35,7 +35,7 @@ type QueryRes struct {
 	TimeoutCounts         bool                              `json:"timeoutCounts"`
 	TimeoutHits           bool                              `json:"timeoutHits"`
 	UserData              map[string]interface{}            `json:"userData"`
-	ABTestVariantID       string                            `json:"abTestVariantID"`
+	ABTestVariantID       int                               `json:"abTestVariantID"`
 }
 
 type AppliedRule struct {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | yes     
| Need Doc update   | no


## Describe your change

`abTestVariantID` is a int not a string, see: https://www.algolia.com/doc/api-reference/api-methods/search/?language=javascript#method-response-abtestvariantid

## What problem is this fixing?

error while unmarshalling the result of a query