### PR TITLE
fix(response): AutomaticRadius is a float not a string

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -9,7 +9,7 @@ import (
 type QueryRes struct {
 	AppliedRules          []AppliedRule                     `json:"appliedRules"`
 	AroundLatLng          string                            `json:"aroundLatLng"`
-	AutomaticRadius       string                            `json:"automaticRadius"`
+	AutomaticRadius       float64                           `json:"automaticRadius"`
 	ExhaustiveFacetsCount bool                              `json:"exhaustiveFacetsCount"`
 	ExhaustiveNbHits      bool                              `json:"exhaustiveNbHits"`
 	Explain               map[string]map[string]interface{} `json:"explain"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | yes    
| Related Issue     | 
| Need Doc update   | no


## Describe your change

AutomaticRadius is a float: https://www.algolia.com/doc/api-reference/api-methods/search/?language=javascript#method-response-automaticradius

## What problem is this fixing?

^ see above