### PR TITLE
fix: algolia_err, use pointers

### DIFF
--- a/algolia/errs/algolia_err.go
+++ b/algolia/errs/algolia_err.go
@@ -26,10 +26,17 @@ func IsAlgoliaErr(err error) (*AlgoliaErr, bool) {
 	if err == nil {
 		return nil, false
 	}
+
 	e, ok := err.(AlgoliaErr)
-	if !ok {
+	eptr, okPtr := err.(*AlgoliaErr)
+	if !ok && !okPtr {
 		return nil, false
 	}
+
+	if okPtr {
+		return eptr, true
+	}
+
 	return &e, true
 }
 

--- a/algolia/errs/algolia_err_test.go
+++ b/algolia/errs/algolia_err_test.go
@@ -1,0 +1,23 @@
+package errs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAlgoliaErr(t *testing.T) {
+	actual, ok := IsAlgoliaErr(nil)
+	require.Nil(t, actual)
+	require.False(t, ok)
+
+	_, ok = IsAlgoliaErr(fmt.Errorf("random error"))
+	require.False(t, ok)
+
+	_, ok = IsAlgoliaErr(&AlgoliaErr{})
+	require.True(t, ok)
+
+	_, ok = IsAlgoliaErr(AlgoliaErr{})
+	require.True(t, ok)
+}

--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -233,5 +233,5 @@ func unmarshalToError(r io.ReadCloser) error {
 	if err != nil {
 		return err
 	}
-	return algoliaErr
+	return &algoliaErr
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

In go errors are interfaces, so they can be also pointers. So we need to for values and pointer in the type cast.

See: https://play.golang.org/p/VUR8qafldKk

Thanks to @marchelbling for spotting the need of the double check