### PR TITLE
Add check for ObjectIDProvider interface

### DIFF
--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -53,7 +53,17 @@ func waitWithRetry(f func() (bool, error)) error {
 	}
 }
 
+// ObjectIDProvider can generate object ID.
+type ObjectIDProvider interface {
+	ObjectID() string
+}
+
 func getObjectID(object interface{}) (string, bool) {
+	o, ok := object.(ObjectIDProvider)
+	if ok {
+		return o.ObjectID(), true
+	}
+
 	data, err := json.Marshal(object)
 	if err != nil {
 		return "", false


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

 Check if object implements `ObjectIDProvider` interface, if yes then respect it
and don't do heavy `json.Marshal`/`json.Unmarshal` operations.

## What problem is this fixing?

In the `utils.getObjectID()` function we do `json.Marshal()` and `json.Unmarshal`. Then in `buildRequest` we do `json.Marshal` again. This can be pretty time consuming.
