### PR TITLE
fix: update analytics regional host name template

### DIFF
--- a/algolia/analytics/utils.go
+++ b/algolia/analytics/utils.go
@@ -11,7 +11,7 @@ import (
 func defaultHosts(r region.Region) (hosts []*transport.StatefulHost) {
 	switch r {
 	case region.EU, region.US:
-		hosts = append(hosts, transport.NewStatefulHost(fmt.Sprintf("%s.analytics.algolia.com", r), call.IsReadWrite))
+		hosts = append(hosts, transport.NewStatefulHost(fmt.Sprintf("analytics.%s.algolia.com", r), call.IsReadWrite))
 	default:
 		hosts = append(hosts, transport.NewStatefulHost("analytics.algolia.com", call.IsReadWrite))
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

All our regional APIs use the following structure: `$feature.$region.algolia.$tld`. For analytics, the `$region` was misplaced. 

## What problem is this fixing?

Incorrect analytics domain meaning that reigonalized Analytics / A/B Tests calls would previously fail.