### PR TITLE
feat(index): add exists method

### DIFF
--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/algolia/algoliasearch-client-go/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/algolia/errs"
 	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
 	"github.com/algolia/algoliasearch-client-go/algolia/transport"
 )
@@ -95,4 +96,17 @@ func (i *Index) GetStatus(taskID int) (res TaskStatusRes, err error) {
 	path := i.path("/task/%d", taskID)
 	err = i.transport.Request(&res, http.MethodGet, path, nil, call.Read)
 	return
+}
+
+// Exists returns whether an initialized index exists or not, along with a nil
+// error. When encountering a network error, a non-nil error is returned along
+// with false.
+func (i *Index) Exists() (bool, error) {
+	_, err := i.GetSettings()
+	_, ok := errs.IsAlgoliaErr(err)
+	if !ok && err != nil {
+		return false, err
+	}
+	_, ok = errs.IsAlgoliaErrWithCode(err, http.StatusNotFound)
+	return !ok, nil
 }

--- a/cts/index/exists_test.go
+++ b/cts/index/exists_test.go
@@ -1,0 +1,26 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExists(t *testing.T) {
+	t.Parallel()
+	_, index, _ := cts.InitSearchClient1AndIndex(t)
+
+	ok, err := index.Exists()
+	require.False(t, ok)
+	require.NoError(t, err)
+
+	res, err := index.SaveObject(map[string]string{"attribute": "value"})
+	require.NoError(t, err)
+	err = res.Wait()
+	require.NoError(t, err)
+
+	ok, _ = index.Exists()
+	require.True(t, ok)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #512  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

This adds the `Index.Exists` method in the client. It follows the [spec](https://github.com/algolia/algoliasearch-client-specs/blob/master/features/index-exists.md) and [common test suite](https://github.com/algolia/algoliasearch-client-specs/tree/master/common-test-suite#Exists).
