### PR TITLE
Improve performances of body encoding

### DIFF
--- a/algolia/debug/debug.go
+++ b/algolia/debug/debug.go
@@ -1,13 +1,9 @@
 package debug
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
-	"strings"
+	"time"
 )
 
 var debug bool
@@ -34,14 +30,18 @@ func Display(itf interface{}) {
 	if !debug {
 		return
 	}
+	start := time.Now()
+	var msg string
 	switch v := itf.(type) {
 	case *http.Request:
-		printRequest(v)
+		msg = debugRequest(v)
 	case *http.Response:
-		printResponse(v)
+		msg = debugResponse(v)
 	default:
-		fmt.Printf("do not know how to debug-print %#v\n", v)
+		msg = fmt.Sprintf("do not know how to display %#v", v)
 	}
+	Println(msg)
+	fmt.Printf("took %s\n", time.Now().Sub(start))
 }
 
 func Println(a ...interface{}) {
@@ -54,49 +54,4 @@ func Printf(format string, a ...interface{}) {
 	}
 	msg := fmt.Sprintf(format, a...)
 	fmt.Printf("> ALGOLIA DEBUG: %s", msg)
-}
-
-func copyReadCloser(r io.ReadCloser) (io.ReadCloser, string) {
-	if r == nil {
-		return nil, ""
-	}
-	data, err := ioutil.ReadAll(r)
-	_ = r.Close()
-	if err != nil {
-		return nil, ""
-	}
-	return ioutil.NopCloser(bytes.NewReader(data)), string(data)
-}
-
-func prettyPrintJSON(input, prefix string) string {
-	var b bytes.Buffer
-	err := json.Indent(&b, []byte(input), prefix, "  ")
-	if err != nil {
-		return input
-	}
-	return strings.TrimSuffix(b.String(), "\n")
-}
-
-func printRequest(req *http.Request) {
-	var body string
-	req.Body, body = copyReadCloser(req.Body)
-	body = prettyPrintJSON(body, "\t")
-	fmt.Printf("> ALGOLIA DEBUG request:\n\tmethod=%q\n\turl=%q\n", req.Method, req.URL)
-	for k, v := range req.Header {
-		str := strings.Join(v, ",")
-		if strings.Contains(strings.ToLower(k), "algolia") {
-			str = strings.Repeat("*", len(str))
-		}
-		fmt.Printf("\theader=%s:%q\n", k, str)
-	}
-	fmt.Printf("\tbody=\n\t%s\n", body)
-}
-
-func printResponse(res *http.Response) {
-	var body string
-	if res != nil {
-		res.Body, body = copyReadCloser(res.Body)
-	}
-	body = prettyPrintJSON(body, "\t")
-	fmt.Printf("> ALGOLIA DEBUG response:\n\tbody=\n\t%s\n", body)
 }

--- a/algolia/debug/utils.go
+++ b/algolia/debug/utils.go
@@ -1,0 +1,109 @@
+package debug
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/algolia/algoliasearch-client-go/algolia/compression"
+)
+
+func copyReadCloser(r io.ReadCloser) (io.ReadCloser, string) {
+	if r == nil {
+		return nil, ""
+	}
+	data, err := ioutil.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		return nil, ""
+	}
+	return ioutil.NopCloser(bytes.NewReader(data)), string(data)
+}
+
+func decodeGzipContent(in string) (string, error) {
+	gr, err := gzip.NewReader(strings.NewReader(in))
+	if err != nil {
+		return in, fmt.Errorf("cannot open content with gzip.Reader: %v", err)
+	}
+	out, err := ioutil.ReadAll(gr)
+	if err != nil {
+		return in, fmt.Errorf("cannot read content from gzip.Reader: %v", err)
+	}
+	return string(out), nil
+}
+
+func extractBody(body io.ReadCloser, c compression.Compression) (io.ReadCloser, string) {
+	if body == nil {
+		return nil, ""
+	}
+
+	reader, content := copyReadCloser(body)
+
+	switch c {
+	case compression.GZIP:
+		decodedContent, err := decodeGzipContent(content)
+		if err == nil {
+			content = decodedContent
+		}
+	}
+
+	return reader, content
+}
+
+func prettyPrintJSON(input string) string {
+	var b bytes.Buffer
+	err := json.Indent(&b, []byte(input), "\t", "  ")
+	if err != nil {
+		return input
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func debugRequest(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+
+	var body string
+
+	switch req.Header.Get("Content-Encoding") {
+	case "gzip":
+		req.Body, body = extractBody(req.Body, compression.GZIP)
+	default:
+		req.Body, body = extractBody(req.Body, compression.None)
+	}
+
+	msg := fmt.Sprintf("> ALGOLIA DEBUG request:\n")
+	msg += fmt.Sprintf("\tmethod=%q\n", req.Method)
+	msg += fmt.Sprintf("\turl=%q\n", req.URL)
+
+	for k, v := range req.Header {
+		str := strings.Join(v, ",")
+		if strings.Contains(strings.ToLower(k), "algolia") {
+			str = strings.Repeat("*", len(str))
+		}
+		msg += fmt.Sprintf("\theader=%s:%q\n", k, str)
+	}
+	msg += fmt.Sprintf("\tbody=\n\t%s\n", prettyPrintJSON(body))
+
+	return msg
+}
+
+func debugResponse(res *http.Response) string {
+	if res == nil {
+		return ""
+	}
+
+	var body string
+	res.Body, body = extractBody(res.Body, compression.None)
+
+	msg := fmt.Sprintf("> ALGOLIA DEBUG response:\n")
+	msg += fmt.Sprintf("\tbody=\n\t%s\n", prettyPrintJSON(body))
+
+	return msg
+}

--- a/algolia/transport/transport_test.go
+++ b/algolia/transport/transport_test.go
@@ -10,23 +10,27 @@ import (
 )
 
 func TestShouldCompress(t *testing.T) {
+	fakeBody := map[string]interface{}{}
 	for _, c := range []struct {
 		compression compression.Compression
 		method      string
+		body        interface{}
 		expected    bool
 	}{
-		{0, "", false},
-		{compression.None, "", false},
-		{compression.None, http.MethodPost, false},
-		{compression.None, http.MethodPut, false},
-		{compression.None, http.MethodDelete, false},
-		{compression.None, http.MethodGet, false},
-		{compression.GZIP, http.MethodPost, true},
-		{compression.GZIP, http.MethodPut, true},
-		{compression.GZIP, http.MethodDelete, false},
-		{compression.GZIP, http.MethodGet, false},
+		{0, "", nil, false},
+		{compression.None, "", nil, false},
+		{compression.None, http.MethodPost, fakeBody, false},
+		{compression.None, http.MethodPut, fakeBody, false},
+		{compression.None, http.MethodDelete, fakeBody, false},
+		{compression.None, http.MethodGet, fakeBody, false},
+		{compression.GZIP, http.MethodPost, fakeBody, true},
+		{compression.GZIP, http.MethodPut, fakeBody, true},
+		{compression.GZIP, http.MethodDelete, fakeBody, false},
+		{compression.GZIP, http.MethodGet, fakeBody, false},
+		{compression.GZIP, http.MethodPost, nil, false},
+		{compression.GZIP, http.MethodPut, nil, false},
 	} {
-		got := shouldCompress(c.compression, c.method)
+		got := shouldCompress(c.compression, c.method, c.body)
 		require.Equal(t, c.expected, got, "compression=%d method=%q", c.compression, c.method)
 	}
 }


### PR DESCRIPTION
While enabling GZIP encoding for POST/PUT requests in previous commits,
we discovered that every JSON request body was serialized in memory
using `json.Marshal` instead of going through a `json.Encoder`, hence
avoiding to load the full content in memory.

This commit is fixing this issue by using an intermediate `json.Encoder`
to prevent in-memory loading of the content. This approach is still
compatible with the GZIP feature which was recently implemented as the
`json.Encoder` is simply the input of the `gzip.Writer` in that case.
This ensure everything is still buffered.
