### PR TITLE
Fix lowercase synonym type

### DIFF
--- a/algolia/search/synonym.go
+++ b/algolia/search/synonym.go
@@ -18,6 +18,12 @@ const (
 	AltCorrection1Type SynonymType = "altCorrection1"
 	AltCorrection2Type SynonymType = "altCorrection2"
 	PlaceholderType    SynonymType = "placeholder"
+
+	// Non-exported constant to represent synonym types as exported
+	// by the Algolia dashboard, which lower-cases the type field.
+	oneWaySynonymTypeLower  SynonymType = "onewaysynonym"
+	altCorrection1TypeLower SynonymType = "altcorrection1"
+	altCorrection2TypeLower SynonymType = "altcorrection2"
 )
 
 type rawSynonym struct{ impl Synonym }
@@ -48,17 +54,17 @@ func (s *rawSynonym) UnmarshalJSON(data []byte) error {
 		err = json.Unmarshal(data, &syn)
 		s.impl = syn
 
-	case OneWaySynonymType:
+	case OneWaySynonymType, oneWaySynonymTypeLower:
 		var syn OneWaySynonym
 		err = json.Unmarshal(data, &syn)
 		s.impl = syn
 
-	case AltCorrection1Type:
+	case AltCorrection1Type, altCorrection1TypeLower:
 		var syn AltCorrection1
 		err = json.Unmarshal(data, &syn)
 		s.impl = syn
 
-	case AltCorrection2Type:
+	case AltCorrection2Type, altCorrection2TypeLower:
 		var syn AltCorrection2
 		err = json.Unmarshal(data, &syn)
 		s.impl = syn

--- a/algolia/search/synonym_alt_correction_1.go
+++ b/algolia/search/synonym_alt_correction_1.go
@@ -40,7 +40,7 @@ func (s *AltCorrection1) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("cannot unmarshal AltCorrection1: %v", err)
 	}
 
-	if synonym.Type != s.Type() {
+	if synonym.Type != s.Type() && synonym.Type != altCorrection1TypeLower {
 		return fmt.Errorf("cannot deserialize synonym of type %s into AltCorretion1", synonym.Type)
 	}
 

--- a/algolia/search/synonym_alt_correction_2.go
+++ b/algolia/search/synonym_alt_correction_2.go
@@ -29,7 +29,7 @@ func (s *AltCorrection2) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("cannot unmarshal AltCorrection2: %v", err)
 	}
 
-	if synonym.Type != s.Type() {
+	if synonym.Type != s.Type() && synonym.Type != altCorrection2TypeLower {
 		return fmt.Errorf("cannot deserialize synonym of type %s into AltCorretion2", synonym.Type)
 	}
 

--- a/algolia/search/synonym_one_way.go
+++ b/algolia/search/synonym_one_way.go
@@ -40,7 +40,7 @@ func (s *OneWaySynonym) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("cannot unmarshal OneWaySynonym: %v", err)
 	}
 
-	if synonym.Type != s.Type() {
+	if synonym.Type != s.Type() && synonym.Type != oneWaySynonymTypeLower {
 		return fmt.Errorf("cannot deserialize synonym of type %s into OneWaySynonym", synonym.Type)
 	}
 

--- a/algolia/search/synonym_test.go
+++ b/algolia/search/synonym_test.go
@@ -1,0 +1,27 @@
+package search
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSynonymUnmarshalType(t *testing.T) {
+	for _, c := range []struct {
+		payload  string
+	}{
+		{`{"type": "synonym"}`},
+		{`{"type": "oneWaySynonym"}`},
+		{`{"type": "altCorrection1"}`},
+		{`{"type": "altCorrection2"}`},
+		{`{"type": "placeholder"}`},
+		{`{"type": "onewaysynonym"}`},
+		{`{"type": "altcorrection1"}`},
+		{`{"type": "altcorrection2"}`},
+	} {
+		var s rawSynonym
+		err := json.Unmarshal([]byte(c.payload), &s)
+		require.NoError(t, err, "payload=%q", c.payload)
+	}
+}


### PR DESCRIPTION
    fixed(synonym): correctly deserialize synonyms set via the Algolia dashboard

    Synonyms saved via the Algolia dashboard see their type field
    lowercased, which means that we at deserialization time, we cannot only
    expect camel casing for synonym types. The impacted synonym types were:
     - `oneWaySynonym` with `onewaysynonym`
     - `altCorrection1` with `altcorrection1`
     - `altCorrection2` with `altcorrection2`

    This commit ensures we correctly deserialize those synonyms, even if
    their type field is lowercased.

    Close #514