### PR TITLE
fixed: use correct type (string) for QueryRes.AutomaticRadius field

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -9,7 +9,7 @@ import (
 type QueryRes struct {
 	AppliedRules          []AppliedRule                     `json:"appliedRules"`
 	AroundLatLng          string                            `json:"aroundLatLng"`
-	AutomaticRadius       float64                           `json:"automaticRadius"`
+	AutomaticRadius       string                            `json:"automaticRadius"`
 	ExhaustiveFacetsCount bool                              `json:"exhaustiveFacetsCount"`
 	ExhaustiveNbHits      bool                              `json:"exhaustiveNbHits"`
 	Explain               map[string]map[string]interface{} `json:"explain"`


### PR DESCRIPTION
Close #518