### PR TITLE
fix(index): add missing Exists() method to the IndexInterface (#537)

### DIFF
--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -9,6 +9,7 @@ type IndexInterface interface {
 	GetAppID() string
 	ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error)
 	Delete(opts ...interface{}) (res DeleteTaskRes, err error)
+	Exists() (exists bool, err error)
 
 	// Indexing
 	GetObject(objectID string, object interface{}, opts ...interface{}) error


### PR DESCRIPTION
Because the Exists() method was missing, the Index could not be mocked
as expected.