### PR TITLE
fix: correctly migrate to Go modules by using v3/ suffix for Semantic Import Versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ os:
   - linux
 
 go:
-  - "1.9"
+  - "1.11"
   - "1.12"
-
-before_install:
-  - go get -u github.com/rakyll/gotest
-  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  - "1.13"
 
 install:
   - make deps

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 all: deps generate lint test
 
 deps:
-	dep ensure -vendor-only
 	go get ./...
 
 generate:
@@ -13,10 +12,10 @@ lint:
 test: unit-tests integration-tests
 
 unit-tests:
-	gotest -v ./algolia/...
+	go test -v ./algolia/...
 
 integration-tests:
-	gotest -v ./cts/...
+	go test -v ./cts/...
 
 clean:
 	rm -f `grep -R -l --include \*.go -F 'DO NOT EDIT' * | grep -v -F 'algolia/internal/gen/'`

--- a/algolia/analytics/client.go
+++ b/algolia/analytics/client.go
@@ -1,10 +1,10 @@
 package analytics
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Client provides methods to interact with the Algolia Analytics API.

--- a/algolia/analytics/client_ab_testing.go
+++ b/algolia/analytics/client_ab_testing.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // AddABTest creates a new AB test.

--- a/algolia/analytics/configuration.go
+++ b/algolia/analytics/configuration.go
@@ -3,8 +3,8 @@ package analytics
 import (
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/region"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Configuration contains all the different parameters one can change to

--- a/algolia/analytics/types_ab_testing.go
+++ b/algolia/analytics/types_ab_testing.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 )
 
 // ABTest presents an AB test input as sent to the Analytics API when creating a

--- a/algolia/analytics/utils.go
+++ b/algolia/analytics/utils.go
@@ -3,9 +3,9 @@ package analytics
 import (
 	"fmt"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/region"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 func defaultHosts(r region.Region) (hosts []*transport.StatefulHost) {

--- a/algolia/debug/utils.go
+++ b/algolia/debug/utils.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
 )
 
 func copyReadCloser(r io.ReadCloser) (io.ReadCloser, string) {

--- a/algolia/insights/client.go
+++ b/algolia/insights/client.go
@@ -3,9 +3,9 @@ package insights
 import (
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Client provides methods to interact with the Algolia Insights API.

--- a/algolia/insights/configuration.go
+++ b/algolia/insights/configuration.go
@@ -3,8 +3,8 @@ package insights
 import (
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/region"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Configuration contains all the different parameters one can change to

--- a/algolia/insights/utils.go
+++ b/algolia/insights/utils.go
@@ -3,9 +3,9 @@ package insights
 import (
 	"fmt"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/region"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 func defaultHosts(r region.Region) (hosts []*transport.StatefulHost) {

--- a/algolia/internal/gen/templates/extract/literal.go.tmpl
+++ b/algolia/internal/gen/templates/extract/literal.go.tmpl
@@ -3,7 +3,7 @@
 package opt
 
 import (
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // Extract{{ title .}} returns the first found {{ title . }}Option from the

--- a/algolia/internal/gen/templates/extract/map_string_interface.go.tmpl
+++ b/algolia/internal/gen/templates/extract/map_string_interface.go.tmpl
@@ -3,7 +3,7 @@
 package opt
 
 import (
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // Extract{{ title .}} returns the first found {{ title . }}Option from the

--- a/algolia/internal/gen/templates/extract/map_string_string.go.tmpl
+++ b/algolia/internal/gen/templates/extract/map_string_string.go.tmpl
@@ -3,7 +3,7 @@
 package opt
 
 import (
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // Extract{{ title .}} returns the first found {{ title . }}Option from the

--- a/algolia/internal/gen/templates/option_test/bool.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/bool.go.tmpl
@@ -6,7 +6,7 @@ import (
     "encoding/json"
     "testing"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
     "github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/option_test/int.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/int.go.tmpl
@@ -6,7 +6,7 @@ import (
     "encoding/json"
     "testing"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
     "github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/option_test/map_string_interface_slice.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/map_string_interface_slice.go.tmpl
@@ -6,7 +6,7 @@ import (
     "encoding/json"
     "testing"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
     "github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/option_test/map_string_string.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/map_string_string.go.tmpl
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/option_test/map_string_string_slice.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/map_string_string_slice.go.tmpl
@@ -6,7 +6,7 @@ import (
     "encoding/json"
     "testing"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
     "github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/option_test/string.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/string.go.tmpl
@@ -6,7 +6,7 @@ import (
     "encoding/json"
     "testing"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
     "github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/option_test/string_slice.go.tmpl
+++ b/algolia/internal/gen/templates/option_test/string_slice.go.tmpl
@@ -6,7 +6,7 @@ import (
     "encoding/json"
     "testing"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
     "github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/gen/templates/query_params.go.tmpl
+++ b/algolia/internal/gen/templates/query_params.go.tmpl
@@ -3,8 +3,8 @@
 package search
 
 import (
-    iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // QueryParams represents all the parameters that can be passed at query time.

--- a/algolia/internal/gen/templates/settings.go.tmpl
+++ b/algolia/internal/gen/templates/settings.go.tmpl
@@ -7,8 +7,8 @@ import (
     "fmt"
     "strings"
 
-    "github.com/algolia/algoliasearch-client-go/algolia/debug"
-    "github.com/algolia/algoliasearch-client-go/algolia/opt"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/debug"
+    "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // Settings represents an index settings configuration.

--- a/algolia/internal/opt/advanced.go
+++ b/algolia/internal/opt/advanced.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAdvanced returns the first found AdvancedOption from the

--- a/algolia/internal/opt/advanced_syntax.go
+++ b/algolia/internal/opt/advanced_syntax.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAdvancedSyntax returns the first found AdvancedSyntaxOption from the

--- a/algolia/internal/opt/advanced_syntax_features.go
+++ b/algolia/internal/opt/advanced_syntax_features.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAdvancedSyntaxFeatures returns the first found AdvancedSyntaxFeaturesOption from the

--- a/algolia/internal/opt/advanced_syntax_features_test.go
+++ b/algolia/internal/opt/advanced_syntax_features_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/advanced_syntax_test.go
+++ b/algolia/internal/opt/advanced_syntax_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/advanced_test.go
+++ b/algolia/internal/opt/advanced_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/allow_compression_of_integer_array.go
+++ b/algolia/internal/opt/allow_compression_of_integer_array.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAllowCompressionOfIntegerArray returns the first found AllowCompressionOfIntegerArrayOption from the

--- a/algolia/internal/opt/allow_compression_of_integer_array_test.go
+++ b/algolia/internal/opt/allow_compression_of_integer_array_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/allow_typos_on_numeric_tokens.go
+++ b/algolia/internal/opt/allow_typos_on_numeric_tokens.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAllowTyposOnNumericTokens returns the first found AllowTyposOnNumericTokensOption from the

--- a/algolia/internal/opt/allow_typos_on_numeric_tokens_test.go
+++ b/algolia/internal/opt/allow_typos_on_numeric_tokens_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/alternatives_as_exact.go
+++ b/algolia/internal/opt/alternatives_as_exact.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAlternativesAsExact returns the first found AlternativesAsExactOption from the

--- a/algolia/internal/opt/alternatives_as_exact_test.go
+++ b/algolia/internal/opt/alternatives_as_exact_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/analytics.go
+++ b/algolia/internal/opt/analytics.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAnalytics returns the first found AnalyticsOption from the

--- a/algolia/internal/opt/analytics_tags.go
+++ b/algolia/internal/opt/analytics_tags.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAnalyticsTags returns the first found AnalyticsTagsOption from the

--- a/algolia/internal/opt/analytics_tags_test.go
+++ b/algolia/internal/opt/analytics_tags_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/analytics_test.go
+++ b/algolia/internal/opt/analytics_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/anchoring.go
+++ b/algolia/internal/opt/anchoring.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAnchoring returns the first found AnchoringOption from the

--- a/algolia/internal/opt/anchoring_test.go
+++ b/algolia/internal/opt/anchoring_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/around_lat_lng.go
+++ b/algolia/internal/opt/around_lat_lng.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAroundLatLng returns the first found AroundLatLngOption from the

--- a/algolia/internal/opt/around_lat_lng_test.go
+++ b/algolia/internal/opt/around_lat_lng_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/around_lat_lng_via_ip.go
+++ b/algolia/internal/opt/around_lat_lng_via_ip.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAroundLatLngViaIP returns the first found AroundLatLngViaIPOption from the

--- a/algolia/internal/opt/around_lat_lng_via_ip_test.go
+++ b/algolia/internal/opt/around_lat_lng_via_ip_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/around_precision.go
+++ b/algolia/internal/opt/around_precision.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAroundPrecision returns the first found AroundPrecisionOption from the

--- a/algolia/internal/opt/around_precision_test.go
+++ b/algolia/internal/opt/around_precision_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/around_radius.go
+++ b/algolia/internal/opt/around_radius.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAroundRadius returns the first found AroundRadiusOption from the

--- a/algolia/internal/opt/around_radius_test.go
+++ b/algolia/internal/opt/around_radius_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/attribute_criteria_computed_by_min_proximity.go
+++ b/algolia/internal/opt/attribute_criteria_computed_by_min_proximity.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAttributeCriteriaComputedByMinProximity returns the first found AttributeCriteriaComputedByMinProximityOption from the

--- a/algolia/internal/opt/attribute_criteria_computed_by_min_proximity_test.go
+++ b/algolia/internal/opt/attribute_criteria_computed_by_min_proximity_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/attribute_for_distinct.go
+++ b/algolia/internal/opt/attribute_for_distinct.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAttributeForDistinct returns the first found AttributeForDistinctOption from the

--- a/algolia/internal/opt/attribute_for_distinct_test.go
+++ b/algolia/internal/opt/attribute_for_distinct_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/attributes_for_faceting.go
+++ b/algolia/internal/opt/attributes_for_faceting.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAttributesForFaceting returns the first found AttributesForFacetingOption from the

--- a/algolia/internal/opt/attributes_for_faceting_test.go
+++ b/algolia/internal/opt/attributes_for_faceting_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/attributes_to_highlight.go
+++ b/algolia/internal/opt/attributes_to_highlight.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAttributesToHighlight returns the first found AttributesToHighlightOption from the

--- a/algolia/internal/opt/attributes_to_highlight_test.go
+++ b/algolia/internal/opt/attributes_to_highlight_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/attributes_to_retrieve.go
+++ b/algolia/internal/opt/attributes_to_retrieve.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAttributesToRetrieve returns the first found AttributesToRetrieveOption from the

--- a/algolia/internal/opt/attributes_to_retrieve_test.go
+++ b/algolia/internal/opt/attributes_to_retrieve_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/attributes_to_snippet.go
+++ b/algolia/internal/opt/attributes_to_snippet.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAttributesToSnippet returns the first found AttributesToSnippetOption from the

--- a/algolia/internal/opt/attributes_to_snippet_test.go
+++ b/algolia/internal/opt/attributes_to_snippet_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/auto_generate_object_id_if_not_exist.go
+++ b/algolia/internal/opt/auto_generate_object_id_if_not_exist.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractAutoGenerateObjectIDIfNotExist returns the first found AutoGenerateObjectIDIfNotExistOption from the

--- a/algolia/internal/opt/auto_generate_object_id_if_not_exist_test.go
+++ b/algolia/internal/opt/auto_generate_object_id_if_not_exist_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/camel_case_attributes.go
+++ b/algolia/internal/opt/camel_case_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractCamelCaseAttributes returns the first found CamelCaseAttributesOption from the

--- a/algolia/internal/opt/camel_case_attributes_test.go
+++ b/algolia/internal/opt/camel_case_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/clear_existing_rules.go
+++ b/algolia/internal/opt/clear_existing_rules.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractClearExistingRules returns the first found ClearExistingRulesOption from the

--- a/algolia/internal/opt/clear_existing_rules_test.go
+++ b/algolia/internal/opt/clear_existing_rules_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/click_analytics.go
+++ b/algolia/internal/opt/click_analytics.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractClickAnalytics returns the first found ClickAnalyticsOption from the

--- a/algolia/internal/opt/click_analytics_test.go
+++ b/algolia/internal/opt/click_analytics_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/cluster_name.go
+++ b/algolia/internal/opt/cluster_name.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractClusterName returns the first found ClusterNameOption from the

--- a/algolia/internal/opt/cluster_name_test.go
+++ b/algolia/internal/opt/cluster_name_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/create_if_not_exists.go
+++ b/algolia/internal/opt/create_if_not_exists.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractCreateIfNotExists returns the first found CreateIfNotExistsOption from the

--- a/algolia/internal/opt/create_if_not_exists_test.go
+++ b/algolia/internal/opt/create_if_not_exists_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/custom_ranking.go
+++ b/algolia/internal/opt/custom_ranking.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractCustomRanking returns the first found CustomRankingOption from the

--- a/algolia/internal/opt/custom_ranking_test.go
+++ b/algolia/internal/opt/custom_ranking_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/decompounded_attributes.go
+++ b/algolia/internal/opt/decompounded_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractDecompoundedAttributes returns the first found DecompoundedAttributesOption from the

--- a/algolia/internal/opt/decompounded_attributes_test.go
+++ b/algolia/internal/opt/decompounded_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/disable_exact_on_attributes.go
+++ b/algolia/internal/opt/disable_exact_on_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractDisableExactOnAttributes returns the first found DisableExactOnAttributesOption from the

--- a/algolia/internal/opt/disable_exact_on_attributes_test.go
+++ b/algolia/internal/opt/disable_exact_on_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/disable_prefix_on_attributes.go
+++ b/algolia/internal/opt/disable_prefix_on_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractDisablePrefixOnAttributes returns the first found DisablePrefixOnAttributesOption from the

--- a/algolia/internal/opt/disable_prefix_on_attributes_test.go
+++ b/algolia/internal/opt/disable_prefix_on_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/disable_typo_tolerance_on_attributes.go
+++ b/algolia/internal/opt/disable_typo_tolerance_on_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractDisableTypoToleranceOnAttributes returns the first found DisableTypoToleranceOnAttributesOption from the

--- a/algolia/internal/opt/disable_typo_tolerance_on_attributes_test.go
+++ b/algolia/internal/opt/disable_typo_tolerance_on_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/disable_typo_tolerance_on_words.go
+++ b/algolia/internal/opt/disable_typo_tolerance_on_words.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractDisableTypoToleranceOnWords returns the first found DisableTypoToleranceOnWordsOption from the

--- a/algolia/internal/opt/disable_typo_tolerance_on_words_test.go
+++ b/algolia/internal/opt/disable_typo_tolerance_on_words_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/distinct.go
+++ b/algolia/internal/opt/distinct.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractDistinct returns the first found DistinctOption from the

--- a/algolia/internal/opt/distinct_test.go
+++ b/algolia/internal/opt/distinct_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/enable_personalization.go
+++ b/algolia/internal/opt/enable_personalization.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractEnablePersonalization returns the first found EnablePersonalizationOption from the

--- a/algolia/internal/opt/enable_personalization_test.go
+++ b/algolia/internal/opt/enable_personalization_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/enable_rules.go
+++ b/algolia/internal/opt/enable_rules.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractEnableRules returns the first found EnableRulesOption from the

--- a/algolia/internal/opt/enable_rules_test.go
+++ b/algolia/internal/opt/enable_rules_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/enabled.go
+++ b/algolia/internal/opt/enabled.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractEnabled returns the first found EnabledOption from the

--- a/algolia/internal/opt/enabled_test.go
+++ b/algolia/internal/opt/enabled_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/exact_on_single_word_query.go
+++ b/algolia/internal/opt/exact_on_single_word_query.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractExactOnSingleWordQuery returns the first found ExactOnSingleWordQueryOption from the

--- a/algolia/internal/opt/exact_on_single_word_query_test.go
+++ b/algolia/internal/opt/exact_on_single_word_query_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/explain.go
+++ b/algolia/internal/opt/explain.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractExplain returns the first found ExplainOption from the

--- a/algolia/internal/opt/explain_test.go
+++ b/algolia/internal/opt/explain_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/extra_headers.go
+++ b/algolia/internal/opt/extra_headers.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractExtraHeaders returns the first found ExtraHeadersOption from the

--- a/algolia/internal/opt/extra_headers_test.go
+++ b/algolia/internal/opt/extra_headers_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/extra_options.go
+++ b/algolia/internal/opt/extra_options.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractExtraOptions returns the first found ExtraOptionsOption from the

--- a/algolia/internal/opt/extra_options_test.go
+++ b/algolia/internal/opt/extra_options_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/extra_url_params.go
+++ b/algolia/internal/opt/extra_url_params.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractExtraURLParams returns the first found ExtraURLParamsOption from the

--- a/algolia/internal/opt/extra_url_params_test.go
+++ b/algolia/internal/opt/extra_url_params_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/facet_filters.go
+++ b/algolia/internal/opt/facet_filters.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractFacetFilters returns the first found FacetFiltersOption from the

--- a/algolia/internal/opt/facet_filters_test.go
+++ b/algolia/internal/opt/facet_filters_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/faceting_after_distinct.go
+++ b/algolia/internal/opt/faceting_after_distinct.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractFacetingAfterDistinct returns the first found FacetingAfterDistinctOption from the

--- a/algolia/internal/opt/faceting_after_distinct_test.go
+++ b/algolia/internal/opt/faceting_after_distinct_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/facets.go
+++ b/algolia/internal/opt/facets.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractFacets returns the first found FacetsOption from the

--- a/algolia/internal/opt/facets_test.go
+++ b/algolia/internal/opt/facets_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/filters.go
+++ b/algolia/internal/opt/filters.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractFilters returns the first found FiltersOption from the

--- a/algolia/internal/opt/filters_test.go
+++ b/algolia/internal/opt/filters_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/forward_to_replicas.go
+++ b/algolia/internal/opt/forward_to_replicas.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractForwardToReplicas returns the first found ForwardToReplicasOption from the

--- a/algolia/internal/opt/forward_to_replicas_test.go
+++ b/algolia/internal/opt/forward_to_replicas_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/get_ranking_info.go
+++ b/algolia/internal/opt/get_ranking_info.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractGetRankingInfo returns the first found GetRankingInfoOption from the

--- a/algolia/internal/opt/get_ranking_info_test.go
+++ b/algolia/internal/opt/get_ranking_info_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/highlight_post_tag.go
+++ b/algolia/internal/opt/highlight_post_tag.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractHighlightPostTag returns the first found HighlightPostTagOption from the

--- a/algolia/internal/opt/highlight_post_tag_test.go
+++ b/algolia/internal/opt/highlight_post_tag_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/highlight_pre_tag.go
+++ b/algolia/internal/opt/highlight_pre_tag.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractHighlightPreTag returns the first found HighlightPreTagOption from the

--- a/algolia/internal/opt/highlight_pre_tag_test.go
+++ b/algolia/internal/opt/highlight_pre_tag_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/hits_per_page.go
+++ b/algolia/internal/opt/hits_per_page.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractHitsPerPage returns the first found HitsPerPageOption from the

--- a/algolia/internal/opt/hits_per_page_test.go
+++ b/algolia/internal/opt/hits_per_page_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/ignore_plurals.go
+++ b/algolia/internal/opt/ignore_plurals.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractIgnorePlurals returns the first found IgnorePluralsOption from the

--- a/algolia/internal/opt/ignore_plurals_test.go
+++ b/algolia/internal/opt/ignore_plurals_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/index_languages.go
+++ b/algolia/internal/opt/index_languages.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractIndexLanguages returns the first found IndexLanguagesOption from the

--- a/algolia/internal/opt/index_languages_test.go
+++ b/algolia/internal/opt/index_languages_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/index_name.go
+++ b/algolia/internal/opt/index_name.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractIndexName returns the first found IndexNameOption from the

--- a/algolia/internal/opt/index_name_test.go
+++ b/algolia/internal/opt/index_name_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/inside_bounding_box.go
+++ b/algolia/internal/opt/inside_bounding_box.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractInsideBoundingBox returns the first found InsideBoundingBoxOption from the

--- a/algolia/internal/opt/inside_bounding_box_test.go
+++ b/algolia/internal/opt/inside_bounding_box_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/inside_polygon.go
+++ b/algolia/internal/opt/inside_polygon.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractInsidePolygon returns the first found InsidePolygonOption from the

--- a/algolia/internal/opt/inside_polygon_test.go
+++ b/algolia/internal/opt/inside_polygon_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/keep_diacritics_on_characters.go
+++ b/algolia/internal/opt/keep_diacritics_on_characters.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractKeepDiacriticsOnCharacters returns the first found KeepDiacriticsOnCharactersOption from the

--- a/algolia/internal/opt/keep_diacritics_on_characters_test.go
+++ b/algolia/internal/opt/keep_diacritics_on_characters_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/length.go
+++ b/algolia/internal/opt/length.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractLength returns the first found LengthOption from the

--- a/algolia/internal/opt/length_test.go
+++ b/algolia/internal/opt/length_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/limit.go
+++ b/algolia/internal/opt/limit.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractLimit returns the first found LimitOption from the

--- a/algolia/internal/opt/limit_test.go
+++ b/algolia/internal/opt/limit_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/max_facet_hits.go
+++ b/algolia/internal/opt/max_facet_hits.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractMaxFacetHits returns the first found MaxFacetHitsOption from the

--- a/algolia/internal/opt/max_facet_hits_test.go
+++ b/algolia/internal/opt/max_facet_hits_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/max_values_per_facet.go
+++ b/algolia/internal/opt/max_values_per_facet.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractMaxValuesPerFacet returns the first found MaxValuesPerFacetOption from the

--- a/algolia/internal/opt/max_values_per_facet_test.go
+++ b/algolia/internal/opt/max_values_per_facet_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/min_proximity.go
+++ b/algolia/internal/opt/min_proximity.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractMinProximity returns the first found MinProximityOption from the

--- a/algolia/internal/opt/min_proximity_test.go
+++ b/algolia/internal/opt/min_proximity_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/min_word_sizefor1_typo.go
+++ b/algolia/internal/opt/min_word_sizefor1_typo.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractMinWordSizefor1Typo returns the first found MinWordSizefor1TypoOption from the

--- a/algolia/internal/opt/min_word_sizefor1_typo_test.go
+++ b/algolia/internal/opt/min_word_sizefor1_typo_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/min_word_sizefor2_typos.go
+++ b/algolia/internal/opt/min_word_sizefor2_typos.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractMinWordSizefor2Typos returns the first found MinWordSizefor2TyposOption from the

--- a/algolia/internal/opt/min_word_sizefor2_typos_test.go
+++ b/algolia/internal/opt/min_word_sizefor2_typos_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/minimum_around_radius.go
+++ b/algolia/internal/opt/minimum_around_radius.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractMinimumAroundRadius returns the first found MinimumAroundRadiusOption from the

--- a/algolia/internal/opt/minimum_around_radius_test.go
+++ b/algolia/internal/opt/minimum_around_radius_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/numeric_attributes_for_filtering.go
+++ b/algolia/internal/opt/numeric_attributes_for_filtering.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractNumericAttributesForFiltering returns the first found NumericAttributesForFilteringOption from the

--- a/algolia/internal/opt/numeric_attributes_for_filtering_test.go
+++ b/algolia/internal/opt/numeric_attributes_for_filtering_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/numeric_filters.go
+++ b/algolia/internal/opt/numeric_filters.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractNumericFilters returns the first found NumericFiltersOption from the

--- a/algolia/internal/opt/numeric_filters_test.go
+++ b/algolia/internal/opt/numeric_filters_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/offset.go
+++ b/algolia/internal/opt/offset.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractOffset returns the first found OffsetOption from the

--- a/algolia/internal/opt/offset_test.go
+++ b/algolia/internal/opt/offset_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/optional_filters.go
+++ b/algolia/internal/opt/optional_filters.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractOptionalFilters returns the first found OptionalFiltersOption from the

--- a/algolia/internal/opt/optional_filters_test.go
+++ b/algolia/internal/opt/optional_filters_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/optional_words.go
+++ b/algolia/internal/opt/optional_words.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractOptionalWords returns the first found OptionalWordsOption from the

--- a/algolia/internal/opt/optional_words_test.go
+++ b/algolia/internal/opt/optional_words_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/page.go
+++ b/algolia/internal/opt/page.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractPage returns the first found PageOption from the

--- a/algolia/internal/opt/page_test.go
+++ b/algolia/internal/opt/page_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/pagination_limited_to.go
+++ b/algolia/internal/opt/pagination_limited_to.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractPaginationLimitedTo returns the first found PaginationLimitedToOption from the

--- a/algolia/internal/opt/pagination_limited_to_test.go
+++ b/algolia/internal/opt/pagination_limited_to_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/percentile_computation.go
+++ b/algolia/internal/opt/percentile_computation.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractPercentileComputation returns the first found PercentileComputationOption from the

--- a/algolia/internal/opt/percentile_computation_test.go
+++ b/algolia/internal/opt/percentile_computation_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/personalization_impact.go
+++ b/algolia/internal/opt/personalization_impact.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractPersonalizationImpact returns the first found PersonalizationImpactOption from the

--- a/algolia/internal/opt/personalization_impact_test.go
+++ b/algolia/internal/opt/personalization_impact_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/primary.go
+++ b/algolia/internal/opt/primary.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractPrimary returns the first found PrimaryOption from the

--- a/algolia/internal/opt/primary_test.go
+++ b/algolia/internal/opt/primary_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/query.go
+++ b/algolia/internal/opt/query.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractQuery returns the first found QueryOption from the

--- a/algolia/internal/opt/query_languages.go
+++ b/algolia/internal/opt/query_languages.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractQueryLanguages returns the first found QueryLanguagesOption from the

--- a/algolia/internal/opt/query_languages_test.go
+++ b/algolia/internal/opt/query_languages_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/query_test.go
+++ b/algolia/internal/opt/query_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/query_type.go
+++ b/algolia/internal/opt/query_type.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractQueryType returns the first found QueryTypeOption from the

--- a/algolia/internal/opt/query_type_test.go
+++ b/algolia/internal/opt/query_type_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/ranking.go
+++ b/algolia/internal/opt/ranking.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRanking returns the first found RankingOption from the

--- a/algolia/internal/opt/ranking_test.go
+++ b/algolia/internal/opt/ranking_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/referers.go
+++ b/algolia/internal/opt/referers.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractReferers returns the first found ReferersOption from the

--- a/algolia/internal/opt/referers_test.go
+++ b/algolia/internal/opt/referers_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/remove_stop_words.go
+++ b/algolia/internal/opt/remove_stop_words.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRemoveStopWords returns the first found RemoveStopWordsOption from the

--- a/algolia/internal/opt/remove_stop_words_test.go
+++ b/algolia/internal/opt/remove_stop_words_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/remove_words_if_no_results.go
+++ b/algolia/internal/opt/remove_words_if_no_results.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRemoveWordsIfNoResults returns the first found RemoveWordsIfNoResultsOption from the

--- a/algolia/internal/opt/remove_words_if_no_results_test.go
+++ b/algolia/internal/opt/remove_words_if_no_results_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/replace_existing_synonyms.go
+++ b/algolia/internal/opt/replace_existing_synonyms.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractReplaceExistingSynonyms returns the first found ReplaceExistingSynonymsOption from the

--- a/algolia/internal/opt/replace_existing_synonyms_test.go
+++ b/algolia/internal/opt/replace_existing_synonyms_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/replace_synonyms_in_highlight.go
+++ b/algolia/internal/opt/replace_synonyms_in_highlight.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractReplaceSynonymsInHighlight returns the first found ReplaceSynonymsInHighlightOption from the

--- a/algolia/internal/opt/replace_synonyms_in_highlight_test.go
+++ b/algolia/internal/opt/replace_synonyms_in_highlight_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/replicas.go
+++ b/algolia/internal/opt/replicas.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractReplicas returns the first found ReplicasOption from the

--- a/algolia/internal/opt/replicas_test.go
+++ b/algolia/internal/opt/replicas_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/response_fields.go
+++ b/algolia/internal/opt/response_fields.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractResponseFields returns the first found ResponseFieldsOption from the

--- a/algolia/internal/opt/response_fields_test.go
+++ b/algolia/internal/opt/response_fields_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/restrict_highlight_and_snippet_arrays.go
+++ b/algolia/internal/opt/restrict_highlight_and_snippet_arrays.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRestrictHighlightAndSnippetArrays returns the first found RestrictHighlightAndSnippetArraysOption from the

--- a/algolia/internal/opt/restrict_highlight_and_snippet_arrays_test.go
+++ b/algolia/internal/opt/restrict_highlight_and_snippet_arrays_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/restrict_indices.go
+++ b/algolia/internal/opt/restrict_indices.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRestrictIndices returns the first found RestrictIndicesOption from the

--- a/algolia/internal/opt/restrict_indices_test.go
+++ b/algolia/internal/opt/restrict_indices_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/restrict_searchable_attributes.go
+++ b/algolia/internal/opt/restrict_searchable_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRestrictSearchableAttributes returns the first found RestrictSearchableAttributesOption from the

--- a/algolia/internal/opt/restrict_searchable_attributes_test.go
+++ b/algolia/internal/opt/restrict_searchable_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/restrict_sources.go
+++ b/algolia/internal/opt/restrict_sources.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRestrictSources returns the first found RestrictSourcesOption from the

--- a/algolia/internal/opt/restrict_sources_test.go
+++ b/algolia/internal/opt/restrict_sources_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/rule_contexts.go
+++ b/algolia/internal/opt/rule_contexts.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractRuleContexts returns the first found RuleContextsOption from the

--- a/algolia/internal/opt/rule_contexts_test.go
+++ b/algolia/internal/opt/rule_contexts_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/safe.go
+++ b/algolia/internal/opt/safe.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSafe returns the first found SafeOption from the

--- a/algolia/internal/opt/safe_test.go
+++ b/algolia/internal/opt/safe_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/scopes.go
+++ b/algolia/internal/opt/scopes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractScopes returns the first found ScopesOption from the

--- a/algolia/internal/opt/scopes_test.go
+++ b/algolia/internal/opt/scopes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/searchable_attributes.go
+++ b/algolia/internal/opt/searchable_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSearchableAttributes returns the first found SearchableAttributesOption from the

--- a/algolia/internal/opt/searchable_attributes_test.go
+++ b/algolia/internal/opt/searchable_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/separators_to_index.go
+++ b/algolia/internal/opt/separators_to_index.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSeparatorsToIndex returns the first found SeparatorsToIndexOption from the

--- a/algolia/internal/opt/separators_to_index_test.go
+++ b/algolia/internal/opt/separators_to_index_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/similar_query.go
+++ b/algolia/internal/opt/similar_query.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSimilarQuery returns the first found SimilarQueryOption from the

--- a/algolia/internal/opt/similar_query_test.go
+++ b/algolia/internal/opt/similar_query_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/snippet_ellipsis_text.go
+++ b/algolia/internal/opt/snippet_ellipsis_text.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSnippetEllipsisText returns the first found SnippetEllipsisTextOption from the

--- a/algolia/internal/opt/snippet_ellipsis_text_test.go
+++ b/algolia/internal/opt/snippet_ellipsis_text_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/sort_facet_values_by.go
+++ b/algolia/internal/opt/sort_facet_values_by.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSortFacetValuesBy returns the first found SortFacetValuesByOption from the

--- a/algolia/internal/opt/sort_facet_values_by_test.go
+++ b/algolia/internal/opt/sort_facet_values_by_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/sum_or_filters_scores.go
+++ b/algolia/internal/opt/sum_or_filters_scores.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSumOrFiltersScores returns the first found SumOrFiltersScoresOption from the

--- a/algolia/internal/opt/sum_or_filters_scores_test.go
+++ b/algolia/internal/opt/sum_or_filters_scores_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/synonyms.go
+++ b/algolia/internal/opt/synonyms.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractSynonyms returns the first found SynonymsOption from the

--- a/algolia/internal/opt/synonyms_test.go
+++ b/algolia/internal/opt/synonyms_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/tag_filters.go
+++ b/algolia/internal/opt/tag_filters.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractTagFilters returns the first found TagFiltersOption from the

--- a/algolia/internal/opt/tag_filters_test.go
+++ b/algolia/internal/opt/tag_filters_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/type.go
+++ b/algolia/internal/opt/type.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractType returns the first found TypeOption from the

--- a/algolia/internal/opt/type_test.go
+++ b/algolia/internal/opt/type_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/typo_tolerance.go
+++ b/algolia/internal/opt/typo_tolerance.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractTypoTolerance returns the first found TypoToleranceOption from the

--- a/algolia/internal/opt/typo_tolerance_test.go
+++ b/algolia/internal/opt/typo_tolerance_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/unretrievable_attributes.go
+++ b/algolia/internal/opt/unretrievable_attributes.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractUnretrievableAttributes returns the first found UnretrievableAttributesOption from the

--- a/algolia/internal/opt/unretrievable_attributes_test.go
+++ b/algolia/internal/opt/unretrievable_attributes_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/user_data.go
+++ b/algolia/internal/opt/user_data.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractUserData returns the first found UserDataOption from the

--- a/algolia/internal/opt/user_data_test.go
+++ b/algolia/internal/opt/user_data_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/user_token.go
+++ b/algolia/internal/opt/user_token.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractUserToken returns the first found UserTokenOption from the

--- a/algolia/internal/opt/user_token_test.go
+++ b/algolia/internal/opt/user_token_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/internal/opt/valid_until.go
+++ b/algolia/internal/opt/valid_until.go
@@ -3,7 +3,7 @@
 package opt
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ExtractValidUntil returns the first found ValidUntilOption from the

--- a/algolia/internal/opt/valid_until_test.go
+++ b/algolia/internal/opt/valid_until_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/opt/around_radius.go
+++ b/algolia/opt/around_radius.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 )
 
 // AroundRadiusOption is a wrapper for an AroundRadius option parameter. It holds

--- a/algolia/opt/distinct.go
+++ b/algolia/opt/distinct.go
@@ -3,7 +3,7 @@ package opt
 import (
 	"encoding/json"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 )
 
 // DistinctOption is a wrapper for an Distinct option parameter. It holds

--- a/algolia/opt/inside_bounding_box.go
+++ b/algolia/opt/inside_bounding_box.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 )
 
 // InsideBoundingBoxOption is a wrapper for an InsideBoundingBox option parameter. It holds

--- a/algolia/opt/inside_polygon.go
+++ b/algolia/opt/inside_polygon.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 )
 
 // InsidePolygonOption is a wrapper for an InsidePolygon option parameter. It holds

--- a/algolia/opt/typo_tolerance.go
+++ b/algolia/opt/typo_tolerance.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 )
 
 // TypoToleranceOption is a wrapper for an TypoTolerance option parameter. It holds

--- a/algolia/opt/utils.go
+++ b/algolia/opt/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/debug"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/debug"
 )
 
 // InsertOrReplaceOption inserts the given opt option into the given slice of

--- a/algolia/search/account.go
+++ b/algolia/search/account.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
 )
 
 // Account provides methods to interact with the Algolia Search API on multiple

--- a/algolia/search/client.go
+++ b/algolia/search/client.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 const (

--- a/algolia/search/client_interface.go
+++ b/algolia/search/client_interface.go
@@ -1,6 +1,6 @@
 package search
 
-import "github.com/algolia/algoliasearch-client-go/algolia/call"
+import "github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 
 type ClientInterface interface {
 	// Misc

--- a/algolia/search/client_keys.go
+++ b/algolia/search/client_keys.go
@@ -3,8 +3,8 @@ package search
 import (
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 )
 
 // GetAPIKey retrieves the API key identified by the given keyID.

--- a/algolia/search/client_mcm.go
+++ b/algolia/search/client_mcm.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // ListClusters list all the clusters managed by MCM.

--- a/algolia/search/client_multiple.go
+++ b/algolia/search/client_multiple.go
@@ -3,7 +3,7 @@ package search
 import (
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 )
 
 // MultipleBatch applies multiple indexing operations on potentially multiple

--- a/algolia/search/client_operations.go
+++ b/algolia/search/client_operations.go
@@ -1,7 +1,7 @@
 package search
 
 import (
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // CopyRules copies the rules from the given source index into the destination one.

--- a/algolia/search/client_personalization.go
+++ b/algolia/search/client_personalization.go
@@ -3,7 +3,7 @@ package search
 import (
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 )
 
 // SetPersonalizationStrategy defines and override the full configuration of

--- a/algolia/search/configuration.go
+++ b/algolia/search/configuration.go
@@ -3,8 +3,8 @@ package search
 import (
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Configuration contains all the different parameters one can change to

--- a/algolia/search/generate_secured_api_key.go
+++ b/algolia/search/generate_secured_api_key.go
@@ -6,9 +6,9 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // GenerateSecuredAPIKey generates a public API key intended to restrict access

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Index provides methods to interact with the Algolia Search API on a single

--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -1,6 +1,6 @@
 package search
 
-import "github.com/algolia/algoliasearch-client-go/algolia/wait"
+import "github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
 
 type IndexInterface interface {
 	// Misc

--- a/algolia/search/index_objects.go
+++ b/algolia/search/index_objects.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/iterator"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/iterator"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
 )
 
 // GetObject retrieves the record identified by the given objectID and

--- a/algolia/search/index_rules.go
+++ b/algolia/search/index_rules.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // GetRule retrieves the rule identified by the given objectID.

--- a/algolia/search/index_settings.go
+++ b/algolia/search/index_settings.go
@@ -3,9 +3,9 @@ package search
 import (
 	"net/http"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // GetSettings retrieves the settings of the index.

--- a/algolia/search/index_synonyms.go
+++ b/algolia/search/index_synonyms.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // GetSynonym retrieves the synonym identified by the given objectID.

--- a/algolia/search/key.go
+++ b/algolia/search/key.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 // Key represents an Algolia API key used by the API to identify and/or restrict

--- a/algolia/search/key_test.go
+++ b/algolia/search/key_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/stretchr/testify/require"
 )
 

--- a/algolia/search/mcm.go
+++ b/algolia/search/mcm.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 type ListClustersRes struct {

--- a/algolia/search/object_iterator.go
+++ b/algolia/search/object_iterator.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/iterator"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/iterator"
 )
 
 // ObjectIterator represents an iterator over records of an index.

--- a/algolia/search/query_params.go
+++ b/algolia/search/query_params.go
@@ -3,8 +3,8 @@
 package search
 
 import (
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // QueryParams represents all the parameters that can be passed at query time.

--- a/algolia/search/requests_indexing.go
+++ b/algolia/search/requests_indexing.go
@@ -1,8 +1,8 @@
 package search
 
 import (
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 type IndexOperation struct {

--- a/algolia/search/requests_key.go
+++ b/algolia/search/requests_key.go
@@ -1,8 +1,8 @@
 package search
 
 import (
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 type KeyQueryParams struct {

--- a/algolia/search/requests_multiple.go
+++ b/algolia/search/requests_multiple.go
@@ -1,8 +1,8 @@
 package search
 
 import (
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 type IndexedGetObject struct {

--- a/algolia/search/requests_multiple_test.go
+++ b/algolia/search/requests_multiple_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 func TestSerializationNestedArraysInMultipleQueries(t *testing.T) {

--- a/algolia/search/requests_rules.go
+++ b/algolia/search/requests_rules.go
@@ -1,8 +1,8 @@
 package search
 
 import (
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 type searchRulesParams struct {

--- a/algolia/search/requests_search.go
+++ b/algolia/search/requests_search.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
 )
 
 type searchReq struct {

--- a/algolia/search/requests_search_test.go
+++ b/algolia/search/requests_search_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 func TestNewSearchParams_ExtraOptionsOverride(t *testing.T) {

--- a/algolia/search/requests_synonyms.go
+++ b/algolia/search/requests_synonyms.go
@@ -1,8 +1,8 @@
 package search
 
 import (
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 type searchSynonymsParams struct {

--- a/algolia/search/rule.go
+++ b/algolia/search/rule.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // Rule represents an Algolia query rule.

--- a/algolia/search/rule_iterator.go
+++ b/algolia/search/rule_iterator.go
@@ -3,7 +3,7 @@ package search
 import (
 	"io"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/debug"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/debug"
 )
 
 type RuleIterator struct {

--- a/algolia/search/settings.go
+++ b/algolia/search/settings.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/debug"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/debug"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 // Settings represents an index settings configuration.

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/rand"
-	"github.com/algolia/algoliasearch-client-go/algolia/transport"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/rand"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 const (

--- a/algolia/transport/retry_strategy.go
+++ b/algolia/transport/retry_strategy.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 )
 
 type Outcome int

--- a/algolia/transport/stateful_host.go
+++ b/algolia/transport/stateful_host.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 )
 
 const (

--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
-	"github.com/algolia/algoliasearch-client-go/algolia/debug"
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	iopt "github.com/algolia/algoliasearch-client-go/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/debug"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
 )
 
 const version = "3.3.0"

--- a/algolia/transport/transport_test.go
+++ b/algolia/transport/transport_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
 )
 
 func TestShouldCompress(t *testing.T) {

--- a/algolia/transport/utils.go
+++ b/algolia/transport/utils.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/debug"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/debug"
 )
 
 func init() {

--- a/algolia/transport/utils_test.go
+++ b/algolia/transport/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/account/account_copy_index_test.go
+++ b/cts/account/account_copy_index_test.go
@@ -3,11 +3,11 @@ package account
 import (
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/errs"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/analytics/ab_testing_test.go
+++ b/cts/analytics/ab_testing_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/analytics"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/analytics"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/index/batching_test.go
+++ b/cts/index/batching_test.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/index/exists_test.go
+++ b/cts/index/exists_test.go
@@ -3,7 +3,7 @@ package index
 import (
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/index/indexing_test.go
+++ b/cts/index/indexing_test.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/index/replacing_test.go
+++ b/cts/index/replacing_test.go
@@ -3,10 +3,10 @@ package index
 import (
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/index/rule_test.go
+++ b/cts/index/rule_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 )
 
 func TestQueryRule(t *testing.T) {

--- a/cts/index/search_test.go
+++ b/cts/index/search_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 )
 
 func TestSearch(t *testing.T) {

--- a/cts/index/settings_test.go
+++ b/cts/index/settings_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 )
 
 func TestSettings(t *testing.T) {

--- a/cts/index/synonym_test.go
+++ b/cts/index/synonym_test.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/insights/sending_events_test.go
+++ b/cts/insights/sending_events_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/insights"
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/insights"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/api_keys_test.go
+++ b/cts/search/api_keys_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/copy_index_test.go
+++ b/cts/search/copy_index_test.go
@@ -3,10 +3,10 @@ package search
 import (
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/dns_timeout_test.go
+++ b/cts/search/dns_timeout_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/get_logs_test.go
+++ b/cts/search/get_logs_test.go
@@ -3,8 +3,8 @@ package search
 import (
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/mcm_test.go
+++ b/cts/search/mcm_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/multiple_operations_test.go
+++ b/cts/search/multiple_operations_test.go
@@ -3,9 +3,9 @@ package search
 import (
 	"testing"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/search/secured_api_keys_test.go
+++ b/cts/search/secured_api_keys_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
-	"github.com/algolia/algoliasearch-client-go/algolia/wait"
-	"github.com/algolia/algoliasearch-client-go/cts"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
 

--- a/cts/testing_utils.go
+++ b/cts/testing_utils.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/algolia/algoliasearch-client-go/algolia/analytics"
-	"github.com/algolia/algoliasearch-client-go/algolia/compression"
-	"github.com/algolia/algoliasearch-client-go/algolia/insights"
-	"github.com/algolia/algoliasearch-client-go/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/analytics"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/insights"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 )
 
 func InitSearchClient1AndIndex(t *testing.T) (*search.Client, *search.Index, string) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/algolia/algoliasearch-client-go
+module github.com/algolia/algoliasearch-client-go/v3
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION

[changelog]

**Manual Intervention Required**

Our migration to Go modules starting at version v3.0.0 of this Go API
client was done incorrectly since our module declaration was not
including the required `v3/` suffix. This commit fixes this issue by
respecting the Semantic Import Versioning described by the Go wiki.

**Step 1/2**

To update your project which depends on the Algolia Go API client, you
need to replace all `github.com/algolia/algoliasearch-client-go/*`
import statements with `github.com/algolia/algoliasearch-client-go/v3/*`
instead. The following shell one-liner can be used to perform this
change:

```
for f in $(find . -type f); do
  sed -i '' 's:github.com/algolia/algoliasearch-client-go:github.com/algolia/algoliasearch-client-go/v3:g' $f
done

for f in $(find . -type f); do
  sed -i 's:github.com/algolia/algoliasearch-client-go:github.com/algolia/algoliasearch-client-go/v3:g' $f
done
```

**Step 2/2**

After that, make sure to import the Algolia Go client dependency as such
in your `go.mod` file:

```
require github.com/algolia/algoliasearch-client-go/v3 v3.X.Y
```

where `v3.X.z` stands for the exact release tag you want to use.