### PR TITLE
feat(key): add Client.GetSecuredAPIKeyRemainingValidity() (#536)

### DIFF
--- a/algolia/errs/errors.go
+++ b/algolia/errs/errors.go
@@ -6,12 +6,16 @@ import (
 )
 
 var (
-	ErrMissingObjectID    = errors.New("objectID is missing or empty")
-	ErrMissingKeyID       = errors.New("key ID is not set in Key.Value")
-	ErrNoMoreHostToTry    = errors.New("all hosts have been contacted unsuccessfully, it can either be a network error or wrong appID/key credentials were used")
-	ErrIndexAlreadyExists = errors.New("destination index already exists, please delete it first as the CopyIndex cannot hold the responsibility of modifying the destination index")
-	ErrSameAppID          = errors.New("indices cannot target the same application ID, please use Client.CopyIndex for same-app index copy instead")
-	ErrObjectNotFound     = errors.New("object not found in with search responses' hits list")
+	ErrMissingObjectID      = errors.New("objectID is missing or empty")
+	ErrMissingKeyID         = errors.New("key ID is not set in Key.Value")
+	ErrNoMoreHostToTry      = errors.New("all hosts have been contacted unsuccessfully, it can either be a network error or wrong appID/key credentials were used")
+	ErrIndexAlreadyExists   = errors.New("destination index already exists, please delete it first as the CopyIndex cannot hold the responsibility of modifying the destination index")
+	ErrSameAppID            = errors.New("indices cannot target the same application ID, please use Client.CopyIndex for same-app index copy instead")
+	ErrObjectNotFound       = errors.New("object not found in with search responses' hits list")
+	ErrEmptySecuredAPIKey   = errors.New("secured API key cannot be empty")
+	ErrInvalidSecuredAPIKey = errors.New("invalid secured API key, please check that the given key is a secured one")
+	ErrValidUntilNotFound   = errors.New("no validUntil parameter found, please make sure the secured API key has one")
+	ErrValidUntilInvalid    = errors.New("validUntil parameter is invalid, please make sure the secured API key has been generated correctly")
 )
 
 func ErrJSONDecode(data []byte, t string) error {

--- a/algolia/search/client_interface.go
+++ b/algolia/search/client_interface.go
@@ -1,6 +1,10 @@
 package search
 
-import "github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+import (
+	"time"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+)
 
 type ClientInterface interface {
 	// Misc
@@ -25,6 +29,7 @@ type ClientInterface interface {
 	DeleteAPIKey(keyID string, opts ...interface{}) (res DeleteKeyRes, err error)
 	RestoreAPIKey(keyID string, opts ...interface{}) (res RestoreKeyRes, err error)
 	ListAPIKeys(opts ...interface{}) (res ListAPIKeysRes, err error)
+	GetSecuredAPIKeyRemainingValidity(keyID string, opts ...interface{}) (v time.Duration, err error)
 
 	// Multiple methods
 	MultipleBatch(operations []BatchOperationIndexed, opts ...interface{}) (res MultipleBatchRes, err error)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #536
| Need Doc update   | yes


## Describe your change

The remaining validity duration of a secured API generated with the
`opt.ValidUntil()` parameter can now be checked thanks to the new
`GetSecuredAPIKeyRemainingValidity()` method of the `search.Client`.
