### PR TITLE
feat(mcm): add Client.AssignUserIDs() method (#545)

### DIFF
--- a/algolia/search/client_interface.go
+++ b/algolia/search/client_interface.go
@@ -41,6 +41,7 @@ type ClientInterface interface {
 	ListUserIDs(opts ...interface{}) (res ListUserIDsRes, err error)
 	GetUserID(userID string, opts ...interface{}) (res UserID, err error)
 	AssignUserID(userID, clusterName string, opts ...interface{}) (res AssignUserIDRes, err error)
+	AssignUserIDs(userIDs []string, clusterName string, opts ...interface{}) (res AssignUserIDRes, err error)
 	RemoveUserID(userID string, opts ...interface{}) (res RemoveUserIDRes, err error)
 	GetTopUserIDs(opts ...interface{}) (res TopUserIDs, err error)
 	SearchUserIDs(query string, opts ...interface{}) (res SearchUserIDRes, err error)

--- a/algolia/search/client_mcm.go
+++ b/algolia/search/client_mcm.go
@@ -41,6 +41,12 @@ func (c *Client) AssignUserID(userID, clusterName string, opts ...interface{}) (
 	return
 }
 
+func (c *Client) AssignUserIDs(userIDs []string, clusterName string, opts ...interface{}) (res AssignUserIDRes, err error) {
+	body := map[string]interface{}{"cluster": clusterName, "users": userIDs}
+	err = c.transport.Request(&res, http.MethodPost, "/1/clusters/mapping/batch", body, call.Write, opts...)
+	return
+}
+
 // RemoveUserID deletes the given userID managed by MCM.
 func (c *Client) RemoveUserID(userID string, opts ...interface{}) (res RemoveUserIDRes, err error) {
 	opts = opt.InsertExtraHeader(opts, "X-Algolia-User-ID", userID)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #545
| Need Doc update   | yes


## Describe your change

Multiple MCM user IDs can now be assigned in a single call by using
`Client.AssignUserIDs()` method.