### PR TITLE
Invalid validuntil for get secured api key remaining validity

### DIFF
--- a/algolia/errs/errors.go
+++ b/algolia/errs/errors.go
@@ -14,7 +14,7 @@ var (
 	ErrObjectNotFound       = errors.New("object not found in with search responses' hits list")
 	ErrEmptySecuredAPIKey   = errors.New("secured API key cannot be empty")
 	ErrInvalidSecuredAPIKey = errors.New("invalid secured API key, please check that the given key is a secured one")
-	ErrValidUntilNotFound   = errors.New("no validUntil parameter found, please make sure the secured API key has one")
+	ErrValidUntilNotFound   = errors.New("no valid `validUntil` parameter found, please make sure the secured API key has been generated correctly")
 )
 
 func ErrJSONDecode(data []byte, t string) error {

--- a/algolia/errs/errors.go
+++ b/algolia/errs/errors.go
@@ -15,7 +15,6 @@ var (
 	ErrEmptySecuredAPIKey   = errors.New("secured API key cannot be empty")
 	ErrInvalidSecuredAPIKey = errors.New("invalid secured API key, please check that the given key is a secured one")
 	ErrValidUntilNotFound   = errors.New("no validUntil parameter found, please make sure the secured API key has one")
-	ErrValidUntilInvalid    = errors.New("validUntil parameter is invalid, please make sure the secured API key has been generated correctly")
 )
 
 func ErrJSONDecode(data []byte, t string) error {

--- a/algolia/search/client_keys.go
+++ b/algolia/search/client_keys.go
@@ -85,10 +85,9 @@ func (c *Client) GetSecuredAPIKeyRemainingValidity(keyID string, opts ...interfa
 		return
 	}
 
-	ts, err := strconv.Atoi(string(submatch[1]))
-	if err != nil {
-		err = errs.ErrValidUntilInvalid
-	}
+	// Error checking is useless here since the previous regexp already matched
+	// with an integer of maximum length 10.
+	ts, _ := strconv.Atoi(string(submatch[1]))
 
 	v = time.Until(time.Unix(int64(ts), 0))
 	return

--- a/cts/search/secured_api_keys_test.go
+++ b/cts/search/secured_api_keys_test.go
@@ -108,4 +108,12 @@ func TestSecuredAPIKeyParametersValidity(t *testing.T) {
 	require.NoError(t, err)
 	_, err = c.GetSecuredAPIKeyRemainingValidity(securedKey)
 	require.EqualError(t, err, errs.ErrValidUntilNotFound.Error())
+
+	securedKey = cts.GenerateSecuredAPIKeyWithArbitraryParameters(
+		t,
+		searchKey,
+		map[string]interface{}{"validUntil": "NaN"},
+	)
+	_, err = c.GetSecuredAPIKeyRemainingValidity(securedKey)
+	require.EqualError(t, err, errs.ErrValidUntilNotFound.Error())
 }

--- a/cts/testing_utils.go
+++ b/cts/testing_utils.go
@@ -1,6 +1,10 @@
 package cts
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/user"
@@ -14,6 +18,7 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/insights"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
 func InitSearchClient1AndIndex(t *testing.T) (*search.Client, *search.Index, string) {
@@ -120,4 +125,19 @@ func TodayDate() string {
 
 func TodayDateTime() string {
 	return time.Now().Format("2006-01-02_15:04:05")
+}
+
+func GenerateSecuredAPIKeyWithArbitraryParameters(
+	t *testing.T,
+	apiKey string,
+	params map[string]interface{},
+) string {
+	h := hmac.New(sha256.New, []byte(apiKey))
+
+	message := transport.URLEncode(params)
+	_, err := h.Write([]byte(message))
+	require.NoError(t, err)
+
+	checksum := hex.EncodeToString(h.Sum(nil))
+	return base64.StdEncoding.EncodeToString([]byte(checksum + message))
 }


### PR DESCRIPTION
**Summary**

The `errs.ErrValidUntilInvalid` error was introduced to signify that the
`validUntil` string parameter of a secured API key could not be parsed
as an integer by the `Client.GetSecuredAPIKeyRemainingValidity()`
method. However, since this string value is always extracted thanks to a
regexp looking for a integer of maximum length 10, the conversion can
never fail, making this error case useless.

This commit hence removes this useless error which get never returned.
