### PR TITLE
fix(mcm): replace invalid otp.ClusterName with opt.Cluster for SearchUserIDs()

### DIFF
--- a/algolia/internal/gen/options.go
+++ b/algolia/internal/gen/options.go
@@ -156,7 +156,7 @@ var options = []Option{
 	{"extraOptions", Other, map[string]interface{}{}, ""},
 	{"extraURLParams", Other, map[string]string{}, ""},
 	{"scopes", Other, []string{}, ""},
-	{"clusterName", Other, "", ""},
+	{"cluster", Other, "", ""},
 	{"indexName", Other, "", ""},
 	{"limit", Other, 10, ""},
 	{"safe", Other, false, ""},

--- a/algolia/internal/opt/cluster.go
+++ b/algolia/internal/opt/cluster.go
@@ -6,11 +6,11 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
-// ExtractClusterName returns the first found ClusterNameOption from the
+// ExtractCluster returns the first found ClusterOption from the
 // given variadic arguments or nil otherwise.
-func ExtractClusterName(opts ...interface{}) *opt.ClusterNameOption {
+func ExtractCluster(opts ...interface{}) *opt.ClusterOption {
 	for _, o := range opts {
-		if v, ok := o.(*opt.ClusterNameOption); ok {
+		if v, ok := o.(*opt.ClusterOption); ok {
 			return v
 		}
 	}

--- a/algolia/internal/opt/cluster_test.go
+++ b/algolia/internal/opt/cluster_test.go
@@ -10,27 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClusterName(t *testing.T) {
+func TestCluster(t *testing.T) {
 	for _, c := range []struct {
 		opts     []interface{}
-		expected *opt.ClusterNameOption
+		expected *opt.ClusterOption
 	}{
 		{
 			opts:     []interface{}{nil},
-			expected: opt.ClusterName(""),
+			expected: opt.Cluster(""),
 		},
 		{
-			opts:     []interface{}{opt.ClusterName("")},
-			expected: opt.ClusterName(""),
+			opts:     []interface{}{opt.Cluster("")},
+			expected: opt.Cluster(""),
 		},
 		{
-			opts:     []interface{}{opt.ClusterName("content of the string value")},
-			expected: opt.ClusterName("content of the string value"),
+			opts:     []interface{}{opt.Cluster("content of the string value")},
+			expected: opt.Cluster("content of the string value"),
 		},
 	} {
 		var (
-			in  = ExtractClusterName(c.opts...)
-			out opt.ClusterNameOption
+			in  = ExtractCluster(c.opts...)
+			out opt.ClusterOption
 		)
 		data, err := json.Marshal(&in)
 		require.NoError(t, err)

--- a/algolia/opt/cluster.go
+++ b/algolia/opt/cluster.go
@@ -4,19 +4,19 @@ package opt
 
 import "encoding/json"
 
-// ClusterNameOption is a wrapper for an ClusterName option parameter. It holds
+// ClusterOption is a wrapper for an Cluster option parameter. It holds
 // the actual value of the option that can be accessed by calling Get.
-type ClusterNameOption struct {
+type ClusterOption struct {
 	value string
 }
 
-// ClusterName wraps the given value into a ClusterNameOption.
-func ClusterName(v string) *ClusterNameOption {
-	return &ClusterNameOption{v}
+// Cluster wraps the given value into a ClusterOption.
+func Cluster(v string) *ClusterOption {
+	return &ClusterOption{v}
 }
 
 // Get retrieves the actual value of the option parameter.
-func (o *ClusterNameOption) Get() string {
+func (o *ClusterOption) Get() string {
 	if o == nil {
 		return ""
 	}
@@ -24,14 +24,14 @@ func (o *ClusterNameOption) Get() string {
 }
 
 // MarshalJSON implements the json.Marshaler interface for
-// ClusterNameOption.
-func (o ClusterNameOption) MarshalJSON() ([]byte, error) {
+// ClusterOption.
+func (o ClusterOption) MarshalJSON() ([]byte, error) {
 	return json.Marshal(o.value)
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for
-// ClusterNameOption.
-func (o *ClusterNameOption) UnmarshalJSON(data []byte) error {
+// ClusterOption.
+func (o *ClusterOption) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		o.value = ""
 		return nil
@@ -42,17 +42,17 @@ func (o *ClusterNameOption) UnmarshalJSON(data []byte) error {
 // Equal returns true if the given option is equal to the instance one. In case
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
-func (o *ClusterNameOption) Equal(o2 *ClusterNameOption) bool {
+func (o *ClusterOption) Equal(o2 *ClusterOption) bool {
 	if o2 == nil {
 		return o.value == ""
 	}
 	return o.value == o2.value
 }
 
-// ClusterNameEqual returns true if the two options are equal.
+// ClusterEqual returns true if the two options are equal.
 // In case of one option being nil, the value of the other must be nil as well
 // or be set to the default value of this option.
-func ClusterNameEqual(o1, o2 *ClusterNameOption) bool {
+func ClusterEqual(o1, o2 *ClusterOption) bool {
 	if o1 != nil {
 		return o1.Equal(o2)
 	}

--- a/algolia/opt/option_getters_test.go
+++ b/algolia/opt/option_getters_test.go
@@ -308,8 +308,8 @@ func TestOptionGetters(t *testing.T) {
 	var scopes *ScopesOption = nil
 	scopes.Get()
 
-	var clusterName *ClusterNameOption = nil
-	clusterName.Get()
+	var cluster *ClusterOption = nil
+	cluster.Get()
 
 	var indexName *IndexNameOption = nil
 	indexName.Get()

--- a/algolia/search/mcm.go
+++ b/algolia/search/mcm.go
@@ -72,7 +72,7 @@ func (h UserIDHit) UnmarshalHighlightResult(v interface{}) error {
 
 type searchUserIDsReq struct {
 	Query       *opt.QueryOption       `json:"query,omitempty"`
-	ClusterName *opt.ClusterNameOption `json:"clusterName,omitempty"`
+	Cluster     *opt.ClusterOption     `json:"cluster,omitempty"`
 	Page        *opt.PageOption        `json:"page,omitempty"`
 	HitsPerPage *opt.HitsPerPageOption `json:"hitsPerPage,omitempty"`
 }
@@ -80,7 +80,7 @@ type searchUserIDsReq struct {
 func newSearchUserIDsReq(query string, opts ...interface{}) searchUserIDsReq {
 	return searchUserIDsReq{
 		Query:       opt.Query(query),
-		ClusterName: iopt.ExtractClusterName(opts...),
+		Cluster:     iopt.ExtractCluster(opts...),
 		Page:        iopt.ExtractPage(opts...),
 		HitsPerPage: iopt.ExtractHitsPerPage(opts...),
 	}


### PR DESCRIPTION
**Summary**

Fix #551 

The `Client.SearchUserIDs()` method was wrongly accepting
opt.ClusterName optional parameter to filter userIDs search queries
based on the cluster. However, this is rejected by the engine, which
only recognizes and accepts `cluster` payloads. To reflect this, the
`opt.ClusterName` option was renamed into `opt.Cluster` instead.