### PR TITLE
Contextual Query Rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-all: deps generate lint test
-
-deps:
-	go get ./...
+all: generate deps lint test
 
 generate:
 	go generate ./...
+
+deps:
+	go get ./...
 
 lint:
 	golangci-lint run ./...

--- a/algolia/internal/gen/templates/option/literal.go.tmpl
+++ b/algolia/internal/gen/templates/option/literal.go.tmpl
@@ -43,8 +43,11 @@ func (o *{{ .Name }}Option) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *{{ .Name }}Option) Equal(o2 *{{ .Name }}Option) bool {
-    if o2 == nil {
-        return o.value == {{ .DefaultValue }}
+	if o == nil {
+		return o2 == nil || o2.value == {{ .DefaultValue }}
+    }
+	if o2 == nil {
+        return o == nil || o.value == {{ .DefaultValue }}
     }
     return o.value == o2.value
 }

--- a/algolia/opt/advanced.go
+++ b/algolia/opt/advanced.go
@@ -43,8 +43,11 @@ func (o *AdvancedOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AdvancedOption) Equal(o2 *AdvancedOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 0
+	}
 	if o2 == nil {
-		return o.value == 0
+		return o == nil || o.value == 0
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/advanced_syntax.go
+++ b/algolia/opt/advanced_syntax.go
@@ -43,8 +43,11 @@ func (o *AdvancedSyntaxOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AdvancedSyntaxOption) Equal(o2 *AdvancedSyntaxOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/allow_compression_of_integer_array.go
+++ b/algolia/opt/allow_compression_of_integer_array.go
@@ -43,8 +43,11 @@ func (o *AllowCompressionOfIntegerArrayOption) UnmarshalJSON(data []byte) error 
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AllowCompressionOfIntegerArrayOption) Equal(o2 *AllowCompressionOfIntegerArrayOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/allow_typos_on_numeric_tokens.go
+++ b/algolia/opt/allow_typos_on_numeric_tokens.go
@@ -43,8 +43,11 @@ func (o *AllowTyposOnNumericTokensOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AllowTyposOnNumericTokensOption) Equal(o2 *AllowTyposOnNumericTokensOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/analytics.go
+++ b/algolia/opt/analytics.go
@@ -43,8 +43,11 @@ func (o *AnalyticsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AnalyticsOption) Equal(o2 *AnalyticsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/anchoring.go
+++ b/algolia/opt/anchoring.go
@@ -43,8 +43,11 @@ func (o *AnchoringOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AnchoringOption) Equal(o2 *AnchoringOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/around_lat_lng.go
+++ b/algolia/opt/around_lat_lng.go
@@ -43,8 +43,11 @@ func (o *AroundLatLngOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AroundLatLngOption) Equal(o2 *AroundLatLngOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/around_lat_lng_via_ip.go
+++ b/algolia/opt/around_lat_lng_via_ip.go
@@ -43,8 +43,11 @@ func (o *AroundLatLngViaIPOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AroundLatLngViaIPOption) Equal(o2 *AroundLatLngViaIPOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/attribute_criteria_computed_by_min_proximity.go
+++ b/algolia/opt/attribute_criteria_computed_by_min_proximity.go
@@ -43,8 +43,11 @@ func (o *AttributeCriteriaComputedByMinProximityOption) UnmarshalJSON(data []byt
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AttributeCriteriaComputedByMinProximityOption) Equal(o2 *AttributeCriteriaComputedByMinProximityOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/attribute_for_distinct.go
+++ b/algolia/opt/attribute_for_distinct.go
@@ -43,8 +43,11 @@ func (o *AttributeForDistinctOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AttributeForDistinctOption) Equal(o2 *AttributeForDistinctOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/auto_generate_object_id_if_not_exist.go
+++ b/algolia/opt/auto_generate_object_id_if_not_exist.go
@@ -43,8 +43,11 @@ func (o *AutoGenerateObjectIDIfNotExistOption) UnmarshalJSON(data []byte) error 
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *AutoGenerateObjectIDIfNotExistOption) Equal(o2 *AutoGenerateObjectIDIfNotExistOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/clear_existing_rules.go
+++ b/algolia/opt/clear_existing_rules.go
@@ -43,8 +43,11 @@ func (o *ClearExistingRulesOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ClearExistingRulesOption) Equal(o2 *ClearExistingRulesOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/click_analytics.go
+++ b/algolia/opt/click_analytics.go
@@ -43,8 +43,11 @@ func (o *ClickAnalyticsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ClickAnalyticsOption) Equal(o2 *ClickAnalyticsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/cluster.go
+++ b/algolia/opt/cluster.go
@@ -43,8 +43,11 @@ func (o *ClusterOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ClusterOption) Equal(o2 *ClusterOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/create_if_not_exists.go
+++ b/algolia/opt/create_if_not_exists.go
@@ -43,8 +43,11 @@ func (o *CreateIfNotExistsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *CreateIfNotExistsOption) Equal(o2 *CreateIfNotExistsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/enable_personalization.go
+++ b/algolia/opt/enable_personalization.go
@@ -43,8 +43,11 @@ func (o *EnablePersonalizationOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *EnablePersonalizationOption) Equal(o2 *EnablePersonalizationOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/enable_rules.go
+++ b/algolia/opt/enable_rules.go
@@ -43,8 +43,11 @@ func (o *EnableRulesOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *EnableRulesOption) Equal(o2 *EnableRulesOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/enabled.go
+++ b/algolia/opt/enabled.go
@@ -43,8 +43,11 @@ func (o *EnabledOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *EnabledOption) Equal(o2 *EnabledOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/exact_on_single_word_query.go
+++ b/algolia/opt/exact_on_single_word_query.go
@@ -43,8 +43,11 @@ func (o *ExactOnSingleWordQueryOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ExactOnSingleWordQueryOption) Equal(o2 *ExactOnSingleWordQueryOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "attribute"
+	}
 	if o2 == nil {
-		return o.value == "attribute"
+		return o == nil || o.value == "attribute"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/faceting_after_distinct.go
+++ b/algolia/opt/faceting_after_distinct.go
@@ -43,8 +43,11 @@ func (o *FacetingAfterDistinctOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *FacetingAfterDistinctOption) Equal(o2 *FacetingAfterDistinctOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/filters.go
+++ b/algolia/opt/filters.go
@@ -43,8 +43,11 @@ func (o *FiltersOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *FiltersOption) Equal(o2 *FiltersOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "attribute"
+	}
 	if o2 == nil {
-		return o.value == "attribute"
+		return o == nil || o.value == "attribute"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/forward_to_replicas.go
+++ b/algolia/opt/forward_to_replicas.go
@@ -43,8 +43,11 @@ func (o *ForwardToReplicasOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ForwardToReplicasOption) Equal(o2 *ForwardToReplicasOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/get_ranking_info.go
+++ b/algolia/opt/get_ranking_info.go
@@ -43,8 +43,11 @@ func (o *GetRankingInfoOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *GetRankingInfoOption) Equal(o2 *GetRankingInfoOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/highlight_post_tag.go
+++ b/algolia/opt/highlight_post_tag.go
@@ -43,8 +43,11 @@ func (o *HighlightPostTagOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *HighlightPostTagOption) Equal(o2 *HighlightPostTagOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "</em>"
+	}
 	if o2 == nil {
-		return o.value == "</em>"
+		return o == nil || o.value == "</em>"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/highlight_pre_tag.go
+++ b/algolia/opt/highlight_pre_tag.go
@@ -43,8 +43,11 @@ func (o *HighlightPreTagOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *HighlightPreTagOption) Equal(o2 *HighlightPreTagOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "<em>"
+	}
 	if o2 == nil {
-		return o.value == "<em>"
+		return o == nil || o.value == "<em>"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/hits_per_page.go
+++ b/algolia/opt/hits_per_page.go
@@ -43,8 +43,11 @@ func (o *HitsPerPageOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *HitsPerPageOption) Equal(o2 *HitsPerPageOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 20
+	}
 	if o2 == nil {
-		return o.value == 20
+		return o == nil || o.value == 20
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/index_name.go
+++ b/algolia/opt/index_name.go
@@ -43,8 +43,11 @@ func (o *IndexNameOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *IndexNameOption) Equal(o2 *IndexNameOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/keep_diacritics_on_characters.go
+++ b/algolia/opt/keep_diacritics_on_characters.go
@@ -43,8 +43,11 @@ func (o *KeepDiacriticsOnCharactersOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *KeepDiacriticsOnCharactersOption) Equal(o2 *KeepDiacriticsOnCharactersOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/length.go
+++ b/algolia/opt/length.go
@@ -43,8 +43,11 @@ func (o *LengthOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *LengthOption) Equal(o2 *LengthOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 0
+	}
 	if o2 == nil {
-		return o.value == 0
+		return o == nil || o.value == 0
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/limit.go
+++ b/algolia/opt/limit.go
@@ -43,8 +43,11 @@ func (o *LimitOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *LimitOption) Equal(o2 *LimitOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 10
+	}
 	if o2 == nil {
-		return o.value == 10
+		return o == nil || o.value == 10
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/max_facet_hits.go
+++ b/algolia/opt/max_facet_hits.go
@@ -43,8 +43,11 @@ func (o *MaxFacetHitsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *MaxFacetHitsOption) Equal(o2 *MaxFacetHitsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 10
+	}
 	if o2 == nil {
-		return o.value == 10
+		return o == nil || o.value == 10
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/max_values_per_facet.go
+++ b/algolia/opt/max_values_per_facet.go
@@ -43,8 +43,11 @@ func (o *MaxValuesPerFacetOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *MaxValuesPerFacetOption) Equal(o2 *MaxValuesPerFacetOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 100
+	}
 	if o2 == nil {
-		return o.value == 100
+		return o == nil || o.value == 100
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/min_proximity.go
+++ b/algolia/opt/min_proximity.go
@@ -43,8 +43,11 @@ func (o *MinProximityOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *MinProximityOption) Equal(o2 *MinProximityOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 1
+	}
 	if o2 == nil {
-		return o.value == 1
+		return o == nil || o.value == 1
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/min_word_sizefor1_typo.go
+++ b/algolia/opt/min_word_sizefor1_typo.go
@@ -43,8 +43,11 @@ func (o *MinWordSizefor1TypoOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *MinWordSizefor1TypoOption) Equal(o2 *MinWordSizefor1TypoOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 4
+	}
 	if o2 == nil {
-		return o.value == 4
+		return o == nil || o.value == 4
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/min_word_sizefor2_typos.go
+++ b/algolia/opt/min_word_sizefor2_typos.go
@@ -43,8 +43,11 @@ func (o *MinWordSizefor2TyposOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *MinWordSizefor2TyposOption) Equal(o2 *MinWordSizefor2TyposOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 8
+	}
 	if o2 == nil {
-		return o.value == 8
+		return o == nil || o.value == 8
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/minimum_around_radius.go
+++ b/algolia/opt/minimum_around_radius.go
@@ -43,8 +43,11 @@ func (o *MinimumAroundRadiusOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *MinimumAroundRadiusOption) Equal(o2 *MinimumAroundRadiusOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 0
+	}
 	if o2 == nil {
-		return o.value == 0
+		return o == nil || o.value == 0
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/offset.go
+++ b/algolia/opt/offset.go
@@ -43,8 +43,11 @@ func (o *OffsetOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *OffsetOption) Equal(o2 *OffsetOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 0
+	}
 	if o2 == nil {
-		return o.value == 0
+		return o == nil || o.value == 0
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/page.go
+++ b/algolia/opt/page.go
@@ -43,8 +43,11 @@ func (o *PageOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *PageOption) Equal(o2 *PageOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 0
+	}
 	if o2 == nil {
-		return o.value == 0
+		return o == nil || o.value == 0
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/pagination_limited_to.go
+++ b/algolia/opt/pagination_limited_to.go
@@ -43,8 +43,11 @@ func (o *PaginationLimitedToOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *PaginationLimitedToOption) Equal(o2 *PaginationLimitedToOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 1000
+	}
 	if o2 == nil {
-		return o.value == 1000
+		return o == nil || o.value == 1000
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/percentile_computation.go
+++ b/algolia/opt/percentile_computation.go
@@ -43,8 +43,11 @@ func (o *PercentileComputationOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *PercentileComputationOption) Equal(o2 *PercentileComputationOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/personalization_impact.go
+++ b/algolia/opt/personalization_impact.go
@@ -43,8 +43,11 @@ func (o *PersonalizationImpactOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *PersonalizationImpactOption) Equal(o2 *PersonalizationImpactOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == 100
+	}
 	if o2 == nil {
-		return o.value == 100
+		return o == nil || o.value == 100
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/primary.go
+++ b/algolia/opt/primary.go
@@ -43,8 +43,11 @@ func (o *PrimaryOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *PrimaryOption) Equal(o2 *PrimaryOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/query.go
+++ b/algolia/opt/query.go
@@ -43,8 +43,11 @@ func (o *QueryOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *QueryOption) Equal(o2 *QueryOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/query_type.go
+++ b/algolia/opt/query_type.go
@@ -43,8 +43,11 @@ func (o *QueryTypeOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *QueryTypeOption) Equal(o2 *QueryTypeOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "prefixLast"
+	}
 	if o2 == nil {
-		return o.value == "prefixLast"
+		return o == nil || o.value == "prefixLast"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/remove_words_if_no_results.go
+++ b/algolia/opt/remove_words_if_no_results.go
@@ -43,8 +43,11 @@ func (o *RemoveWordsIfNoResultsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *RemoveWordsIfNoResultsOption) Equal(o2 *RemoveWordsIfNoResultsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "none"
+	}
 	if o2 == nil {
-		return o.value == "none"
+		return o == nil || o.value == "none"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/replace_existing_synonyms.go
+++ b/algolia/opt/replace_existing_synonyms.go
@@ -43,8 +43,11 @@ func (o *ReplaceExistingSynonymsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ReplaceExistingSynonymsOption) Equal(o2 *ReplaceExistingSynonymsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/replace_synonyms_in_highlight.go
+++ b/algolia/opt/replace_synonyms_in_highlight.go
@@ -43,8 +43,11 @@ func (o *ReplaceSynonymsInHighlightOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *ReplaceSynonymsInHighlightOption) Equal(o2 *ReplaceSynonymsInHighlightOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/restrict_highlight_and_snippet_arrays.go
+++ b/algolia/opt/restrict_highlight_and_snippet_arrays.go
@@ -43,8 +43,11 @@ func (o *RestrictHighlightAndSnippetArraysOption) UnmarshalJSON(data []byte) err
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *RestrictHighlightAndSnippetArraysOption) Equal(o2 *RestrictHighlightAndSnippetArraysOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/safe.go
+++ b/algolia/opt/safe.go
@@ -43,8 +43,11 @@ func (o *SafeOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *SafeOption) Equal(o2 *SafeOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/separators_to_index.go
+++ b/algolia/opt/separators_to_index.go
@@ -43,8 +43,11 @@ func (o *SeparatorsToIndexOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *SeparatorsToIndexOption) Equal(o2 *SeparatorsToIndexOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/similar_query.go
+++ b/algolia/opt/similar_query.go
@@ -43,8 +43,11 @@ func (o *SimilarQueryOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *SimilarQueryOption) Equal(o2 *SimilarQueryOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/sort_facet_values_by.go
+++ b/algolia/opt/sort_facet_values_by.go
@@ -43,8 +43,11 @@ func (o *SortFacetValuesByOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *SortFacetValuesByOption) Equal(o2 *SortFacetValuesByOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == "count"
+	}
 	if o2 == nil {
-		return o.value == "count"
+		return o == nil || o.value == "count"
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/sum_or_filters_scores.go
+++ b/algolia/opt/sum_or_filters_scores.go
@@ -43,8 +43,11 @@ func (o *SumOrFiltersScoresOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *SumOrFiltersScoresOption) Equal(o2 *SumOrFiltersScoresOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == false
+	}
 	if o2 == nil {
-		return o.value == false
+		return o == nil || o.value == false
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/synonyms.go
+++ b/algolia/opt/synonyms.go
@@ -43,8 +43,11 @@ func (o *SynonymsOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *SynonymsOption) Equal(o2 *SynonymsOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == true
+	}
 	if o2 == nil {
-		return o.value == true
+		return o == nil || o.value == true
 	}
 	return o.value == o2.value
 }

--- a/algolia/opt/user_token.go
+++ b/algolia/opt/user_token.go
@@ -43,8 +43,11 @@ func (o *UserTokenOption) UnmarshalJSON(data []byte) error {
 // the given option is nil, we checked the instance one is set to the default
 // value of the option.
 func (o *UserTokenOption) Equal(o2 *UserTokenOption) bool {
+	if o == nil {
+		return o2 == nil || o2.value == ""
+	}
 	if o2 == nil {
-		return o.value == ""
+		return o == nil || o.value == ""
 	}
 	return o.value == o2.value
 }

--- a/algolia/search/rule.go
+++ b/algolia/search/rule.go
@@ -66,6 +66,22 @@ func (r Rule) Equal(r2 Rule) bool {
 	return true
 }
 
+func (r Rule) MarshalJSON() ([]byte, error) {
+	type _Rule Rule
+	type _RuleWithOptionalCondition struct {
+		Condition *RuleCondition `json:"condition,omitempty"`
+		_Rule
+	}
+
+	var tmp _RuleWithOptionalCondition
+	tmp._Rule = _Rule(r)
+
+	if r.Condition != (RuleCondition{}) {
+		tmp.Condition = &r.Condition
+	}
+	return json.Marshal(tmp)
+}
+
 // Equal returns true if the TimeRanges are equal. It returns false otherwise.
 func (r TimeRange) Equal(r2 TimeRange) bool {
 	return r.From.Equal(r2.From) && r.Until.Equal(r2.Until)

--- a/algolia/search/rule_condition.go
+++ b/algolia/search/rule_condition.go
@@ -3,8 +3,8 @@ package search
 import "encoding/json"
 
 type RuleCondition struct {
-	Anchoring    RulePatternAnchoring `json:"anchoring"`
-	Pattern      string               `json:"pattern"`
+	Anchoring    RulePatternAnchoring `json:"anchoring,omitempty"`
+	Pattern      string               `json:"pattern,omitempty"`
 	Context      string               `json:"context,omitempty"`
 	Alternatives *Alternatives        `json:"alternatives,omitempty"`
 }

--- a/cts/index/rule_test.go
+++ b/cts/index/rule_test.go
@@ -34,7 +34,7 @@ func TestQueryRule(t *testing.T) {
 
 	{
 		res, err := index.SetSettings(search.Settings{
-			AttributesForFaceting: opt.AttributesForFaceting("brand"),
+			AttributesForFaceting: opt.AttributesForFaceting("brand", "model"),
 		})
 		require.NoError(t, err)
 		g.Collect(res)
@@ -85,6 +85,29 @@ func TestQueryRule(t *testing.T) {
 			},
 			Enabled: opt.Enabled(true),
 		},
+		{
+			ObjectID: "query_promo",
+			Consequence: search.RuleConsequence{
+				Params: &search.RuleParams{
+					QueryParams: search.QueryParams{
+						Filters: opt.Filters("brand:OnePlus"),
+					},
+				},
+			},
+		},
+		{
+			ObjectID: "query_promo_summer",
+			Condition: search.RuleCondition{
+				Context: "summer",
+			},
+			Consequence: search.RuleConsequence{
+				Params: &search.RuleParams{
+					QueryParams: search.QueryParams{
+						Filters: opt.Filters("model:One"),
+					},
+				},
+			},
+		},
 	}
 
 	{
@@ -100,6 +123,12 @@ func TestQueryRule(t *testing.T) {
 	}
 
 	require.NoError(t, g.Wait())
+
+	{
+		res, err := index.Search("", opt.RuleContexts("summer"))
+		require.NoError(t, err, "should find search results")
+		require.Equal(t, 1, res.NbHits)
+	}
 
 	{
 		var wg sync.WaitGroup


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #542 
| Need Doc update   | no


## Describe your change

Makes Query Rules' condition and condition fields optional to let query rules trigger contextually (when using `opt.RuleContexts` at search time).

@Ant-hem @nunomaduro Skip the review of the first commit, this is a bug fix on generated files (a better null-checking). The contextual query rules related change is fairly small.