### PR TITLE
chore(travis): bump golangci and remove os since default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: go
 
-os:
-  - linux
-
 go:
   - "1.11"
   - "1.12"
   - "1.13"
 
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.19.1
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
   - make deps
   - make generate
 


### PR DESCRIPTION
## Describe your change

Bump golangci-lint.
Drop os since it's already the default.

## What problem is this fixing?

Cleaner travis script and keeping up to date.