### PR TITLE
fix(search): correctly encode index name in URIs (#574)

### DIFF
--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -3,6 +3,7 @@ package search
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
@@ -31,7 +32,7 @@ func newIndex(client *Client, name string) *Index {
 }
 
 func (i *Index) path(format string, a ...interface{}) string {
-	prefix := fmt.Sprintf("/1/indexes/%s", i.name)
+	prefix := fmt.Sprintf("/1/indexes/%s", url.QueryEscape(i.name))
 	suffix := fmt.Sprintf(format, a...)
 	return prefix + suffix
 }

--- a/cts/index/url_encoding_index_name_test.go
+++ b/cts/index/url_encoding_index_name_test.go
@@ -1,0 +1,67 @@
+package index
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
+	"github.com/algolia/algoliasearch-client-go/v3/cts"
+)
+
+func TestEnableURLEncodingIndexName(t *testing.T) {
+	t.Parallel()
+
+	var (
+		client              = cts.InitSearchClient1(t)
+		indexNames          []string
+		baseIndexName       = cts.GenerateIndexName(t)
+		forbiddenCharacters = "$&*,/;\\`|~"
+	)
+
+	for c := 0; c < 128; c++ {
+		if !unicode.IsPrint(rune(c)) ||
+			unicode.IsNumber(rune(c)) ||
+			unicode.IsLetter(rune(c)) ||
+			strings.Contains(forbiddenCharacters, string(c)) {
+			continue
+		}
+		indexNames = append(indexNames, baseIndexName+string(c))
+	}
+
+	g := wait.NewGroup()
+
+	for _, indexName := range indexNames {
+		res, err := client.InitIndex(indexName).SaveObject(map[string]string{
+			"objectID": indexName,
+		})
+		require.NoError(t, err, "should save object in index %q", indexName)
+		g.Collect(res)
+	}
+
+	require.NoError(t, g.Wait())
+
+	res, err := client.ListIndices()
+	require.NoError(t, err)
+
+	var listedIndexNames []string
+	for _, index := range res.Items {
+		listedIndexNames = append(listedIndexNames, index.Name)
+	}
+
+	for _, indexName := range indexNames {
+		found := assert.Contains(t, listedIndexNames, indexName)
+		if !found {
+			fmt.Printf("%s not found among listed indices (%d):\n", indexName, len(listedIndexNames))
+			for _, listedIndexName := range listedIndexNames {
+				if strings.Contains(listedIndexName, baseIndexName) {
+					fmt.Printf("> %s\n", listedIndexName)
+				}
+			}
+		}
+	}
+}

--- a/cts/testing_utils.go
+++ b/cts/testing_utils.go
@@ -23,12 +23,31 @@ import (
 
 func InitSearchClient1AndIndex(t *testing.T) (*search.Client, *search.Index, string) {
 	c := InitSearchClient1(t)
-	canonicalName := GenerateCanonicalPrefixName()
-	indexName := canonicalName + "_" + t.Name()
-	indexName = strings.Replace(indexName, "/", "_", -1)
-	indexName = strings.Replace(indexName, " ", "_", -1)
+	indexName := GenerateIndexName(t)
 	i := c.InitIndex(indexName)
 	return c, i, indexName
+}
+
+func GenerateIndexName(t *testing.T) string {
+	indexName := GenerateCanonicalPrefixName() + "_" + t.Name()
+	indexName = cleanIndexName(indexName)
+	return indexName
+}
+
+func cleanIndexName(indexName string) string {
+	for _, char := range []string{
+		"/",
+		"-",
+		".",
+		":",
+		" ",
+		"%",
+		"+",
+		"^",
+	} {
+		indexName = strings.Replace(indexName, char, "_", -1)
+	}
+	return indexName
 }
 
 func InitSearchClient1(t *testing.T) *search.Client {
@@ -120,11 +139,11 @@ func Retry(shouldStopFunc func() bool) {
 }
 
 func TodayDate() string {
-	return time.Now().Format("2006-01-02")
+	return time.Now().Format("2006_01_02")
 }
 
 func TodayDateTime() string {
-	return time.Now().Format("2006-01-02_15:04:05")
+	return time.Now().Format("2006_01_02_15_04_05")
 }
 
 func GenerateSecuredAPIKeyWithArbitraryParameters(


### PR DESCRIPTION
We've recently identified that the user-provided index name, when passed
to the URL internally, was not URL-encoded as one would expect. This
could result in the user targetting wrong indices, either when using the Go
client, or other API clients, including frontend integrations.

After multiple internal discussions, we finally decided to introduce
this change, even though it may be breaking for some users, in a minor
version. We consider that the future benefits of fixing this issue for
future new users holds more positive impact than the negative one of
having existing users to have to manually ensure their index names are
correct.

Close #574