### PR TITLE
Fix/legacy filters deserialization

### DIFF
--- a/algolia/internal/opt/facet_filters_test.go
+++ b/algolia/internal/opt/facet_filters_test.go
@@ -93,3 +93,50 @@ func TestFacetFilters(t *testing.T) {
 		require.Equal(t, *c.expected, out)
 	}
 }
+
+func TestFacetFilters_LegacyDeserialization(t *testing.T) {
+	for _, c := range []struct {
+		payload  string
+		expected *opt.FacetFiltersOption
+	}{
+		{
+			`"filter1:value1"`,
+			opt.FacetFilter("filter1:value1"),
+		},
+		{
+			`" filter1:value1 "`,
+			opt.FacetFilter("filter1:value1"),
+		},
+		{
+			`["filter1:value1"]`,
+			opt.FacetFilter("filter1:value1"),
+		},
+		{
+			`[" filter1:value1 "]`,
+			opt.FacetFilter("filter1:value1"),
+		},
+		{
+			`"filter1:value1,filter2:value2"`,
+			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`" filter1:value1 , filter2:value2 "`,
+			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`["filter1:value1","filter2:value2"]`,
+			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+		},
+	} {
+		var got opt.FacetFiltersOption
+		err := json.Unmarshal([]byte(c.payload), &got)
+		require.NoError(t, err, "cannot unmarshal legacy payload %q for opt.FacetFiltersOption", c.payload)
+
+		require.True(t, got.Equal(c.expected), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+		require.True(t, c.expected.Equal(&got), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+	}
+}

--- a/algolia/internal/opt/numeric_filters_test.go
+++ b/algolia/internal/opt/numeric_filters_test.go
@@ -93,3 +93,50 @@ func TestNumericFilters(t *testing.T) {
 		require.Equal(t, *c.expected, out)
 	}
 }
+
+func TestNumericFilters_LegacyDeserialization(t *testing.T) {
+	for _, c := range []struct {
+		payload  string
+		expected *opt.NumericFiltersOption
+	}{
+		{
+			`"filter1:value1"`,
+			opt.NumericFilter("filter1:value1"),
+		},
+		{
+			`" filter1:value1 "`,
+			opt.NumericFilter("filter1:value1"),
+		},
+		{
+			`["filter1:value1"]`,
+			opt.NumericFilter("filter1:value1"),
+		},
+		{
+			`[" filter1:value1 "]`,
+			opt.NumericFilter("filter1:value1"),
+		},
+		{
+			`"filter1:value1,filter2:value2"`,
+			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`" filter1:value1 , filter2:value2 "`,
+			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`["filter1:value1","filter2:value2"]`,
+			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+		},
+	} {
+		var got opt.NumericFiltersOption
+		err := json.Unmarshal([]byte(c.payload), &got)
+		require.NoError(t, err, "cannot unmarshal legacy payload %q for opt.NumericFiltersOption", c.payload)
+
+		require.True(t, got.Equal(c.expected), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+		require.True(t, c.expected.Equal(&got), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+	}
+}

--- a/algolia/internal/opt/optional_filters_test.go
+++ b/algolia/internal/opt/optional_filters_test.go
@@ -93,3 +93,50 @@ func TestOptionalFilters(t *testing.T) {
 		require.Equal(t, *c.expected, out)
 	}
 }
+
+func TestOptionalFilters_LegacyDeserialization(t *testing.T) {
+	for _, c := range []struct {
+		payload  string
+		expected *opt.OptionalFiltersOption
+	}{
+		{
+			`"filter1:value1"`,
+			opt.OptionalFilter("filter1:value1"),
+		},
+		{
+			`" filter1:value1 "`,
+			opt.OptionalFilter("filter1:value1"),
+		},
+		{
+			`["filter1:value1"]`,
+			opt.OptionalFilter("filter1:value1"),
+		},
+		{
+			`[" filter1:value1 "]`,
+			opt.OptionalFilter("filter1:value1"),
+		},
+		{
+			`"filter1:value1,filter2:value2"`,
+			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`" filter1:value1 , filter2:value2 "`,
+			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`["filter1:value1","filter2:value2"]`,
+			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+		},
+	} {
+		var got opt.OptionalFiltersOption
+		err := json.Unmarshal([]byte(c.payload), &got)
+		require.NoError(t, err, "cannot unmarshal legacy payload %q for opt.OptionalFiltersOption", c.payload)
+
+		require.True(t, got.Equal(c.expected), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+		require.True(t, c.expected.Equal(&got), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+	}
+}

--- a/algolia/internal/opt/tag_filters_test.go
+++ b/algolia/internal/opt/tag_filters_test.go
@@ -93,3 +93,50 @@ func TestTagFilters(t *testing.T) {
 		require.Equal(t, *c.expected, out)
 	}
 }
+
+func TestTagFilters_LegacyDeserialization(t *testing.T) {
+	for _, c := range []struct {
+		payload  string
+		expected *opt.TagFiltersOption
+	}{
+		{
+			`"filter1:value1"`,
+			opt.TagFilter("filter1:value1"),
+		},
+		{
+			`" filter1:value1 "`,
+			opt.TagFilter("filter1:value1"),
+		},
+		{
+			`["filter1:value1"]`,
+			opt.TagFilter("filter1:value1"),
+		},
+		{
+			`[" filter1:value1 "]`,
+			opt.TagFilter("filter1:value1"),
+		},
+		{
+			`"filter1:value1,filter2:value2"`,
+			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`" filter1:value1 , filter2:value2 "`,
+			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`["filter1:value1","filter2:value2"]`,
+			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+		},
+	} {
+		var got opt.TagFiltersOption
+		err := json.Unmarshal([]byte(c.payload), &got)
+		require.NoError(t, err, "cannot unmarshal legacy payload %q for opt.TagFiltersOption", c.payload)
+
+		require.True(t, got.Equal(c.expected), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+		require.True(t, c.expected.Equal(&got), "legacy payload %q should deserialize to %#v but got %#v instead", c.payload, c.expected, got)
+	}
+}

--- a/algolia/opt/composable_filter_test.go
+++ b/algolia/opt/composable_filter_test.go
@@ -1,0 +1,91 @@
+package opt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
+	for _, c := range []struct {
+		payload  string
+		expected composableFilterOption
+	}{
+		{
+			`[]`,
+			composableFilterOption{},
+		},
+		{
+			`[[]]`,
+			composableFilterOption{},
+		},
+		{
+			`"color:green"`,
+			composableFilterOption{[][]string{
+				{`color:green`},
+			}},
+		},
+		{
+			`" color:green "`,
+			composableFilterOption{[][]string{
+				{`color:green`},
+			}},
+		},
+		{
+			`"color:green,color:yellow"`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+			}},
+		},
+		{
+			`" color:green , color:yellow "`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+			}},
+		},
+		{
+			`["color:green","color:yellow"]`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+			}},
+		},
+		{
+			`[" color:green "," color:yellow "]`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+			}},
+		},
+		{
+			`[["color:green"],["color:yellow"]]`,
+			composableFilterOption{[][]string{
+				{`color:green`},
+				{`color:yellow`},
+			}},
+		},
+		{
+			`[[" color:green "],[" color:yellow "]]`,
+			composableFilterOption{[][]string{
+				{`color:green`},
+				{`color:yellow`},
+			}},
+		},
+	} {
+		var got composableFilterOption
+		err := json.Unmarshal([]byte(c.payload), &got)
+		require.NoError(t, err, "cannot unmarshal payload %q", c.payload)
+
+		fGot := got.Get()
+		fExpected := c.expected.Get()
+
+		require.Equal(
+			t,
+			len(fGot),
+			len(fExpected),
+			"expected %v as deserialized filters instead of %v for payload %q",
+			fExpected,
+			fGot,
+			c.payload,
+		)
+	}
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #549
| Need Doc update   | no

## Describe your change

Write a custom deserializer for the private `opt.composableFilterOption` type, which is the shared implementation of both `opt.FacetFilters`, `opt.NumericFilters`, `opt.TagFilters` and `opt.OptionalFilters` types. Tests are also being added to cover all cases.

## What problem is this fixing?

The Go client is now able to correctly deserialize legacy payloads for all filters types, such as string and arrays of strings (we previously only supported the arrays of arrays of strings).