### PR TITLE
fix(analytics): accept region.DE instead of region.EU for Analytics configuration

### DIFF
--- a/algolia/analytics/utils.go
+++ b/algolia/analytics/utils.go
@@ -10,7 +10,7 @@ import (
 
 func defaultHosts(r region.Region) (hosts []*transport.StatefulHost) {
 	switch r {
-	case region.EU, region.US:
+	case region.DE, region.US:
 		hosts = append(hosts, transport.NewStatefulHost(fmt.Sprintf("analytics.%s.algolia.com", r), call.IsReadWrite))
 	default:
 		hosts = append(hosts, transport.NewStatefulHost("analytics.algolia.com", call.IsReadWrite))

--- a/algolia/region/region.go
+++ b/algolia/region/region.go
@@ -5,4 +5,5 @@ type Region string
 const (
 	US Region = "us"
 	EU Region = "eu"
+	DE Region = "de"
 )


### PR DESCRIPTION
The `region.EU` was never accepted by the Analytics API. This commit
introduces the right region `region.DE` and uses it as part of the valid
configurable regions for the Analytics client.