### PR TITLE
fix(recommendation): add app id to the default config

### DIFF
--- a/algolia/recommendation/client.go
+++ b/algolia/recommendation/client.go
@@ -17,6 +17,7 @@ type Client struct {
 func NewClient(appID, apiKey string, region region.Region) *Client {
 	return NewClientWithConfig(
 		Configuration{
+			AppID:  appID,
 			APIKey: apiKey,
 			Region: region,
 		},


### PR DESCRIPTION
chore(travis): add go 1.14

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change
Adding Go 1.14 to the travis.

## What problem is this fixing?
Adding AppId to the recommendation constructor