### PR TITLE
fix: use int64 instead of int (32b integers) to represent task IDs everywhere

### DIFF
--- a/algolia/analytics/client.go
+++ b/algolia/analytics/client.go
@@ -65,6 +65,6 @@ func NewClientWithConfig(config Configuration) *Client {
 	}
 }
 
-func (c *Client) waitTaskSearchClient(index string, taskID int) error {
+func (c *Client) waitTaskSearchClient(index string, taskID int64) error {
 	return c.searchClient.InitIndex(index).WaitTask(taskID)
 }

--- a/algolia/analytics/responses_ab_testing.go
+++ b/algolia/analytics/responses_ab_testing.go
@@ -11,8 +11,8 @@ import (
 type ABTestTaskRes struct {
 	ABTestID int    `json:"abTestID"`
 	Index    string `json:"index"`
-	TaskID   int    `json:"taskID"`
-	wait     func(index string, taskID int) error
+	TaskID   int64  `json:"taskID"`
+	wait     func(index string, taskID int64) error
 }
 
 // Wait blocks until the AB test task completes or if there is an error while

--- a/algolia/search/client_multiple.go
+++ b/algolia/search/client_multiple.go
@@ -16,7 +16,7 @@ func (c *Client) MultipleBatch(operations []BatchOperationIndexed, opts ...inter
 	return
 }
 
-func (c *Client) waitTask(index string, taskID int) error {
+func (c *Client) waitTask(index string, taskID int64) error {
 	return c.InitIndex(index).WaitTask(taskID)
 }
 

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -39,7 +39,7 @@ func (i *Index) path(format string, a ...interface{}) string {
 
 // WaitTask blocks until the task identified by the given taskID is completed on
 // Algolia engine.
-func (i *Index) WaitTask(taskID int) error {
+func (i *Index) WaitTask(taskID int64) error {
 	return waitWithRetry(func() (bool, error) {
 		res, err := i.GetStatus(taskID)
 		if err != nil {
@@ -93,7 +93,7 @@ func (i *Index) Delete(opts ...interface{}) (res DeleteTaskRes, err error) {
 
 // GetStatus retrieves the task status according to the Algolia engine for the
 // given task.
-func (i *Index) GetStatus(taskID int) (res TaskStatusRes, err error) {
+func (i *Index) GetStatus(taskID int64) (res TaskStatusRes, err error) {
 	path := i.path("/task/%d", taskID)
 	err = i.transport.Request(&res, http.MethodGet, path, nil, call.Read)
 	return

--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -4,8 +4,8 @@ import "github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
 
 type IndexInterface interface {
 	// Misc
-	WaitTask(taskID int) error
-	GetStatus(taskID int) (res TaskStatusRes, err error)
+	WaitTask(taskID int64) error
+	GetStatus(taskID int64) (res TaskStatusRes, err error)
 	GetAppID() string
 	ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error)
 	Delete(opts ...interface{}) (res DeleteTaskRes, err error)

--- a/algolia/search/responses_indexing.go
+++ b/algolia/search/responses_indexing.go
@@ -9,8 +9,8 @@ import (
 type SaveObjectRes struct {
 	CreatedAt time.Time `json:"createdAt"`
 	ObjectID  string    `json:"objectID"`
-	TaskID    int       `json:"taskID"`
-	wait      func(taskID int) error
+	TaskID    int64     `json:"taskID"`
+	wait      func(taskID int64) error
 }
 
 func (r SaveObjectRes) Wait() error {
@@ -19,8 +19,8 @@ func (r SaveObjectRes) Wait() error {
 
 type BatchRes struct {
 	ObjectIDs []string `json:"objectIDs"`
-	TaskID    int      `json:"taskID"`
-	wait      func(taskID int) error
+	TaskID    int64    `json:"taskID"`
+	wait      func(taskID int64) error
 }
 
 func (r BatchRes) Wait() error {

--- a/algolia/search/responses_multiple.go
+++ b/algolia/search/responses_multiple.go
@@ -6,9 +6,9 @@ import (
 )
 
 type MultipleBatchRes struct {
-	ObjectIDs []string       `json:"objectIDs"`
-	TaskIDs   map[string]int `json:"taskID"`
-	wait      func(index string, taskID int) error
+	ObjectIDs []string         `json:"objectIDs"`
+	TaskIDs   map[string]int64 `json:"taskID"`
+	wait      func(index string, taskID int64) error
 }
 
 func (r MultipleBatchRes) Wait() error {
@@ -17,7 +17,7 @@ func (r MultipleBatchRes) Wait() error {
 
 	for index, taskID := range r.TaskIDs {
 		wg.Add(1)
-		go func(wg *sync.WaitGroup, index string, taskID int) {
+		go func(wg *sync.WaitGroup, index string, taskID int64) {
 			errs <- r.wait(index, taskID)
 			wg.Done()
 		}(&wg, index, taskID)

--- a/algolia/search/responses_personalization.go
+++ b/algolia/search/responses_personalization.go
@@ -7,6 +7,6 @@ type SetPersonalizationStrategyRes struct {
 }
 
 type GetPersonalizationStrategyRes struct {
-	TaskID int `json:"taskID"`
+	TaskID int64 `json:"taskID"`
 	Strategy
 }

--- a/algolia/search/responses_tasks.go
+++ b/algolia/search/responses_tasks.go
@@ -8,15 +8,15 @@ type TaskStatusRes struct {
 }
 
 type UpdateTaskRes struct {
-	TaskID    int       `json:"taskID"`
+	TaskID    int64     `json:"taskID"`
 	UpdatedAt time.Time `json:"updatedAt"`
-	wait      func(taskID int) error
+	wait      func(taskID int64) error
 }
 
 type DeleteTaskRes struct {
 	DeletedAt time.Time `json:"deletedAt"`
-	TaskID    int       `json:"taskID"`
-	wait      func(taskID int) error
+	TaskID    int64     `json:"taskID"`
+	wait      func(taskID int64) error
 }
 
 func (r UpdateTaskRes) Wait() error { return r.wait(r.TaskID) }

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -29,7 +29,7 @@ func defaultHosts(appID string) (hosts []*transport.StatefulHost) {
 	return
 }
 
-func noWait(_ int) error {
+func noWait(_ int64) error {
 	return nil
 }
 


### PR DESCRIPTION
We've recently noticed that all integers representing task IDs coming
from Algolia were wrongly typed as 32b integers. However, the Algolia
engine is returning JSON numbers which can go beyond the range of 32b: a
JSON number can be as big as 2^53.

For this reason, this commit is changing the type of all the taskID
variables as well as all function accepting task IDs from `int` to `int64`.

This change was automated, for the most part, with the two following sed
commands:

```
find . -name '*.go' -exec gsed -Ei 's/taskID( +)int\)/taskID\1int64\)/' {} \;
find . -name '*.go' -exec gsed -Ei 's/TaskID( +)int/TaskID\1int64/' {} \;
```

Fix #591