### PR TITLE
refactor(transport): ensure early termination upon context cancellation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,27 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-            key: go-cache-1-14
+          key: go-cache-1-14
       - run:
           name: Install golangci-lint linter
           command: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.25.0
       - run:
           name: Check formatting
           command: make lint
+  test-1-11:
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - restore_cache:
+          key: go-cache-1-11
+      - credentials
+      - test:
+          go_version: "1.11"
+      - save_cache:
+          key: go-cache-1-11
+          paths:
+            - "~/go/pkg"
   test-1-12:
     docker:
       - image: circleci/golang:1.12
@@ -93,6 +107,7 @@ workflows:
   build:
     jobs:
       - format
+      - test-1-11
       - test-1-12
       - test-1-13
       - test-1-14

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - gofmt
     - goimports
     - golint
-    - gosimple
     - govet
     - ineffassign
     - misspell

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://godoc.org/github.com/algolia/algoliasearch-client-go"><img src="https://godoc.org/github.com/algolia/algoliasearch-client-go?status.svg" alt="GoDoc"></img></a>
     <a href="https://goreportcard.com/report/github.com/algolia/algoliasearch-client-go"><img src="https://goreportcard.com/badge/github.com/algolia/algoliasearch-client-go" alt="Go Report Card"></img></a>
     <a href="https://github.com/algolia/algoliasearch-client-go/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></img></a>
-    <img src="https://img.shields.io/badge/Go-%3E=1.8-green.svg" alt="Supported version"></img></a>
+    <img src="https://img.shields.io/badge/Go-%3E=1.11-green.svg" alt="Supported version"></img></a>
   </p>
 </p>
 
@@ -25,7 +25,7 @@
 
 ## ✨ Features
 
-* Support Go 1.8 and above
+* Support Go 1.11 and above
 * Typed requests and responses
 * First-class support for user-defined structures
 * Injectable HTTP client


### PR DESCRIPTION
Because we were not checking if the error returning by the underlying
requester, we could not determine if the HTTP call failed because of
user-defined context being cancelled because of a timeout being reached or
an exceeding deadline.

This commit introduce an early return for those cases. This way, we do
not perform multiple retries against other hosts when the user-defined
context is already done, because of a context timeout or a context deadline.

Note that we did not use the error wrapping mechanism from Go 1.13 with
`errors.Is()` and `errors.As()` since we are still supporting Go down to
Go 1.11 for now.

Close #596
