### PR TITLE
fix(analytics): correct AB testing average click pos type

### DIFF
--- a/algolia/analytics/responses_ab_testing.go
+++ b/algolia/analytics/responses_ab_testing.go
@@ -45,7 +45,7 @@ type ABTestResponse struct {
 // VariantResponse represents an AB test's variant as returned by the Analytics
 // API when retrieved as part of a response.
 type VariantResponse struct {
-	AverageClickPosition   int                 `json:"averageClickPosition"`
+	AverageClickPosition   float64             `json:"averageClickPosition"`
 	ClickCount             int                 `json:"clickCount"`
 	ClickThroughRate       float64             `json:"clickThroughRate"`
 	ConversionCount        int                 `json:"conversionCount"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | https://algolia.slack.com/archives/C336MP4UA/p1601275875007500
| Need Doc update   | no


## Describe your change

```
cannot deserialize response's body: json: cannot unmarshal number 15.814493551189196 into Go struct field VariantResponse.variants.averageClickPosition of type int
```
