### PR TITLE
feat(analytics): add tracked search count

### DIFF
--- a/algolia/analytics/responses_ab_testing.go
+++ b/algolia/analytics/responses_ab_testing.go
@@ -54,6 +54,7 @@ type VariantResponse struct {
 	Index                  string              `json:"index"`
 	NoResultCount          int                 `json:"noResultCount"`
 	SearchCount            int                 `json:"searchCount"`
+	TrackedSearchCount     int                 `json:"trackedSearchCount"`
 	TrafficPercentage      int                 `json:"trafficPercentage"`
 	UserCount              int                 `json:"userCount"`
 	CustomSearchParameters *search.QueryParams `json:"customSearchParameters"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix https://github.com/algolia/algoliasearch-client-specs-internal/pull/142
| Need Doc update   | no (already done)


## Describe your change

Add the field `trackedSearchCount` to AB testing metrics returned.