### PR TITLE
fix: Handle response which can't be retried with a proper error

### DIFF
--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -138,6 +138,9 @@ func (t *Transport) Request(
 			cancel()
 			return err
 		default:
+			if err == nil {
+				err = fmt.Errorf("request on host %s failed with response=`%s` and code=%d", h.host, bodyRes, code)
+			}
 			intermediateNetworkErrors = append(intermediateNetworkErrors, err)
 			if bodyRes != nil {
 				if err = bodyRes.Close(); err != nil {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     


## Describe your change

A request can be [retry](https://github.com/algolia/algoliasearch-client-go/blob/6be76833adc02e295d2a184d6855a0865485812b/algolia/transport/retry_strategy.go#L93) if:

1. The request timed out
2. The request triggered a network error
3. The server returned an error response (http code not 2XX or 4XX)

In the 3rd case, the err is nil so the code should generate one on his own

## What problem is this fixing?

return a nil error in the `intermediateNetworkErrors` array
