### PR TITLE
fix: Insights event timestamp serialization

### DIFF
--- a/algolia/insights/types.go
+++ b/algolia/insights/types.go
@@ -28,7 +28,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 
 	var timestamp int64
 	if !e.Timestamp.IsZero() {
-		e.Timestamp.Unix()
+		timestamp = int64(time.Nanosecond) * e.Timestamp.UnixNano() / int64(time.Millisecond)
 	}
 
 	return json.Marshal(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no    
| Related Issue     | Fix #639 
| Need Doc update   | no


## Describe your change

This PR fixes incorrect Insights event timestamp conversion to milliseconds and JSON serialization