### PR TITLE
feat(search): add request options on wait functions

### DIFF
--- a/algolia/search/client_multiple.go
+++ b/algolia/search/client_multiple.go
@@ -16,8 +16,8 @@ func (c *Client) MultipleBatch(operations []BatchOperationIndexed, opts ...inter
 	return
 }
 
-func (c *Client) waitTask(index string, taskID int64) error {
-	return c.InitIndex(index).WaitTask(taskID)
+func (c *Client) waitTask(index string, taskID int64, opts ...interface{}) error {
+	return c.InitIndex(index).WaitTask(taskID, opts...)
 }
 
 // MultipleGetObjects retrieves multiple objects from potentially multiple

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -39,9 +39,9 @@ func (i *Index) path(format string, a ...interface{}) string {
 
 // WaitTask blocks until the task identified by the given taskID is completed on
 // Algolia engine.
-func (i *Index) WaitTask(taskID int64) error {
+func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 	return waitWithRetry(func() (bool, error) {
-		res, err := i.GetStatus(taskID)
+		res, err := i.GetStatus(taskID, opts...)
 		if err != nil {
 			return true, err
 		}
@@ -93,9 +93,9 @@ func (i *Index) Delete(opts ...interface{}) (res DeleteTaskRes, err error) {
 
 // GetStatus retrieves the task status according to the Algolia engine for the
 // given task.
-func (i *Index) GetStatus(taskID int64) (res TaskStatusRes, err error) {
+func (i *Index) GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error) {
 	path := i.path("/task/%d", taskID)
-	err = i.transport.Request(&res, http.MethodGet, path, nil, call.Read)
+	err = i.transport.Request(&res, http.MethodGet, path, nil, call.Read, opts...)
 	return
 }
 

--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -4,8 +4,8 @@ import "github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
 
 type IndexInterface interface {
 	// Misc
-	WaitTask(taskID int64) error
-	GetStatus(taskID int64) (res TaskStatusRes, err error)
+	WaitTask(taskID int64, opts ...interface{}) error
+	GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error)
 	GetAppID() string
 	ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error)
 	Delete(opts ...interface{}) (res DeleteTaskRes, err error)

--- a/algolia/search/responses_indexing.go
+++ b/algolia/search/responses_indexing.go
@@ -10,35 +10,35 @@ type SaveObjectRes struct {
 	CreatedAt time.Time `json:"createdAt"`
 	ObjectID  string    `json:"objectID"`
 	TaskID    int64     `json:"taskID"`
-	wait      func(taskID int64) error
+	wait      func(taskID int64, opts ...interface{}) error
 }
 
-func (r SaveObjectRes) Wait() error {
-	return r.wait(r.TaskID)
+func (r SaveObjectRes) Wait(opts ...interface{}) error {
+	return r.wait(r.TaskID, opts...)
 }
 
 type BatchRes struct {
 	ObjectIDs []string `json:"objectIDs"`
 	TaskID    int64    `json:"taskID"`
-	wait      func(taskID int64) error
+	wait      func(taskID int64, opts ...interface{}) error
 }
 
-func (r BatchRes) Wait() error {
-	return r.wait(r.TaskID)
+func (r BatchRes) Wait(opts ...interface{}) error {
+	return r.wait(r.TaskID, opts...)
 }
 
 type GroupBatchRes struct {
 	Responses []BatchRes
 }
 
-func (r GroupBatchRes) Wait() error {
+func (r GroupBatchRes) Wait(opts ...interface{}) error {
 	var wg sync.WaitGroup
 	errs := make(chan error, len(r.Responses))
 
 	for _, res := range r.Responses {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, res BatchRes) {
-			errs <- res.Wait()
+			errs <- res.Wait(opts...)
 			wg.Done()
 		}(&wg, res)
 	}

--- a/algolia/search/responses_multiple.go
+++ b/algolia/search/responses_multiple.go
@@ -8,17 +8,17 @@ import (
 type MultipleBatchRes struct {
 	ObjectIDs []string         `json:"objectIDs"`
 	TaskIDs   map[string]int64 `json:"taskID"`
-	wait      func(index string, taskID int64) error
+	wait      func(index string, taskID int64, opts ...interface{}) error
 }
 
-func (r MultipleBatchRes) Wait() error {
+func (r MultipleBatchRes) Wait(opts ...interface{}) error {
 	var wg sync.WaitGroup
 	errs := make(chan error, len(r.TaskIDs))
 
 	for index, taskID := range r.TaskIDs {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, index string, taskID int64) {
-			errs <- r.wait(index, taskID)
+			errs <- r.wait(index, taskID, opts...)
 			wg.Done()
 		}(&wg, index, taskID)
 	}

--- a/algolia/search/responses_tasks.go
+++ b/algolia/search/responses_tasks.go
@@ -10,14 +10,14 @@ type TaskStatusRes struct {
 type UpdateTaskRes struct {
 	TaskID    int64     `json:"taskID"`
 	UpdatedAt time.Time `json:"updatedAt"`
-	wait      func(taskID int64) error
+	wait      func(taskID int64, opts ...interface{}) error
 }
 
 type DeleteTaskRes struct {
 	DeletedAt time.Time `json:"deletedAt"`
 	TaskID    int64     `json:"taskID"`
-	wait      func(taskID int64) error
+	wait      func(taskID int64, opts ...interface{}) error
 }
 
-func (r UpdateTaskRes) Wait() error { return r.wait(r.TaskID) }
-func (r DeleteTaskRes) Wait() error { return r.wait(r.TaskID) }
+func (r UpdateTaskRes) Wait(opts ...interface{}) error { return r.wait(r.TaskID, opts...) }
+func (r DeleteTaskRes) Wait(opts ...interface{}) error { return r.wait(r.TaskID, opts...) }

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -29,7 +29,7 @@ func defaultHosts(appID string) (hosts []*transport.StatefulHost) {
 	return
 }
 
-func noWait(_ int64) error {
+func noWait(_ int64, _ ...interface{}) error {
 	return nil
 }
 

--- a/algolia/wait/waitable.go
+++ b/algolia/wait/waitable.go
@@ -5,5 +5,5 @@ package wait
 // the `algolia.Waitable` interface in order to wait for their completion using
 // `algolia.NewGroup()` or `algolia.Wait()` provided helpers.
 type Waitable interface {
-	Wait() error
+	Wait(opts ...interface{}) error
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     


## Describe your change

Add the ability to provide request options on wait task calls .

## What problem is this fixing?

It's not possible to pass `opt.ExposeIntermediateNetworkErrors(true)` to **WaitTask** so in case of network failure, it's impossible to debug it.
