### PR TITLE
feat(Transport): improve error message on unmarshalTo errors

### DIFF
--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"runtime"
@@ -302,10 +303,14 @@ func buildRequest(
 }
 
 func unmarshalTo(r io.ReadCloser, v interface{}) error {
-	err := json.NewDecoder(r).Decode(&v)
+	body, err := ioutil.ReadAll(r)
 	errClose := r.Close()
 	if err != nil {
-		return fmt.Errorf("cannot deserialize response's body: %v", err)
+		return fmt.Errorf("cannot read body: %v", err)
+	}
+	err = json.Unmarshal(body, &v)
+	if err != nil {
+		return fmt.Errorf("cannot deserialize response's body: %v: %s", err, string(body))
 	}
 	if errClose != nil {
 		return fmt.Errorf("cannot close response's body: %v", errClose)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Improve error message on unmarshalTo errors

## What problem is this fixing?

When the client is unable to deserialize a response, there's currently no way to know the original message and what it contains. This PR will improve it.
