### PR TITLE
fix: panic in case of non-retryable error with nil body

### DIFF
--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -135,7 +135,9 @@ func (t *Transport) Request(
 			cancel()
 			return err
 		case Failure:
-			err = unmarshalToError(bodyRes)
+			if bodyRes != nil {
+				err = unmarshalToError(bodyRes)
+			}
 			cancel()
 			return err
 		default:

--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -137,6 +137,8 @@ func (t *Transport) Request(
 		case Failure:
 			if bodyRes != nil {
 				err = unmarshalToError(bodyRes)
+			} else if err == nil {
+				err = fmt.Errorf("undefined network error with code: %v", code)
 			}
 			cancel()
 			return err


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no   
| Related Issue     | Fix #648
| Need Doc update   | no


## Describe your change

In case of non-retryable transport error with nil body, the error is returned directly skipping the attempt to parse the body. 

## What problem is this fixing?

A few HS tickets ([1](https://secure.helpscout.net/conversation/1436477033/335677/), [2](https://secure.helpscout.net/conversation/1434758878/335102?folderId=2966557)) reported the panic happened due to attempt to unmarshal the nil body in case of non-retryable error.