### PR TITLE
fix: query parameter support in Search for facet values parameters list

### DIFF
--- a/algolia/search/requests_search.go
+++ b/algolia/search/requests_search.go
@@ -79,15 +79,15 @@ func newSearchParams(query string, opts ...interface{}) searchParams {
 }
 
 type searchForFacetValuesParams struct {
-	FacetQuery string `json:"facetQuery"`
-	Query *opt.QueryOption `json:"query"`
+	FacetQuery string           `json:"facetQuery"`
+	Query      *opt.QueryOption `json:"query"`
 	QueryParams
 }
 
 func newSearchForFacetValuesParams(query string, opts ...interface{}) searchForFacetValuesParams {
 	return searchForFacetValuesParams{
 		FacetQuery:  query,
-		Query: iopt.ExtractQuery(opts...),
-		QueryParams: newQueryParams( opts...),
+		Query:       iopt.ExtractQuery(opts...),
+		QueryParams: newQueryParams(opts...),
 	}
 }

--- a/algolia/search/requests_search.go
+++ b/algolia/search/requests_search.go
@@ -6,7 +6,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 )
 
 type searchReq struct {
@@ -73,18 +74,20 @@ func newSearchParams(query string, opts ...interface{}) searchParams {
 	return searchParams{
 		Query:       query,
 		QueryParams: newQueryParams(opts...),
-		ExtraParams: opt.ExtractExtraOptions(opts...).Get(),
+		ExtraParams: iopt.ExtractExtraOptions(opts...).Get(),
 	}
 }
 
 type searchForFacetValuesParams struct {
 	FacetQuery string `json:"facetQuery"`
+	Query *opt.QueryOption `json:"query"`
 	QueryParams
 }
 
 func newSearchForFacetValuesParams(query string, opts ...interface{}) searchForFacetValuesParams {
 	return searchForFacetValuesParams{
 		FacetQuery:  query,
-		QueryParams: newQueryParams(opts...),
+		Query: iopt.ExtractQuery(opts...),
+		QueryParams: newQueryParams( opts...),
 	}
 }

--- a/algolia/search/requests_search_test.go
+++ b/algolia/search/requests_search_test.go
@@ -27,3 +27,14 @@ func TestNewSearchParams_ExtraOptionsOverride(t *testing.T) {
 	require.True(t, ok)
 	require.True(t, v)
 }
+
+func TestSearchForFacetValuesParams_IncludeQuery(t *testing.T) {
+	params := newSearchForFacetValuesParams("facet query", opt.Query("search query"), opt.MaxFacetHits(5))
+	data, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
+	require.NotNil(t, m["query"])
+}

--- a/algolia/search/requests_search_test.go
+++ b/algolia/search/requests_search_test.go
@@ -37,4 +37,5 @@ func TestSearchForFacetValuesParams_IncludeQuery(t *testing.T) {
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 	require.NotNil(t, m["query"])
+	require.Equal(t, m["query"], "search query")
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | Fix #654 
| Need Doc update   | no

## Describe your change

Current implementation of `SearchForFacetValues` method ignores `opt.Query` parameter from the variadic parameters list due to `opt.Query` not being a part of `QueryParams` structure.
This PR adds the `opt.Query` parameter to the `searchForFacetValuesParams` structure and fixes this issue.