### PR TITLE
chore: Disable Custom Dictionaries integration tests

### DIFF
--- a/cts/search/dictionaries/compounds_test.go
+++ b/cts/search/dictionaries/compounds_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestCompounds(t *testing.T) {
+	t.Skip("Temporary skip dictionaries tests")
 	t.Parallel()
 	client := cts.InitSearchClient2(t)
 

--- a/cts/search/dictionaries/plurals_test.go
+++ b/cts/search/dictionaries/plurals_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestPlurals(t *testing.T) {
+	t.Skip("Temporary skip dictionaries tests")
 	t.Parallel()
 	client := cts.InitSearchClient2(t)
 

--- a/cts/search/dictionaries/stopwords_test.go
+++ b/cts/search/dictionaries/stopwords_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestStopWords(t *testing.T) {
+	t.Skip("Temporary skip dictionaries tests")
 	t.Parallel()
 	client := cts.InitSearchClient2(t)
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     

## Describe your change

This PR makes the custom dictionaries skip to unblock the CI

## What problem is this fixing?

CI doesn't fail anymore due to always-failing custom dictionaries integration tests