### PR TITLE
feat(index): Make it possible to get index name

### DIFF
--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -71,6 +71,12 @@ func (i *Index) GetAppID() string {
 	return i.appID
 }
 
+// GetName returns the current index name.
+func (i *Index) GetName() string {
+	return i.name
+}
+
+
 // ClearObjects deletes all the records of the index.
 func (i *Index) ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error) {
 	path := i.path("/clear")

--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -7,6 +7,7 @@ type IndexInterface interface {
 	WaitTask(taskID int64, opts ...interface{}) error
 	GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error)
 	GetAppID() string
+	GetName() string
 	ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error)
 	Delete(opts ...interface{}) (res DeleteTaskRes, err error)
 	Exists() (exists bool, err error)

--- a/algolia/search/index_test.go
+++ b/algolia/search/index_test.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"testing"
+)
+
+func TestIndex_GetAppID(t *testing.T) {
+	tests := []struct {
+		name  string
+		appID string
+		want  string
+	}{
+		{
+			appID: "test_app_id",
+			want:  "test_app_id",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Index{
+				appID: tt.appID,
+			}
+			if got := i.GetAppID(); got != tt.want {
+				t.Errorf("GetAppID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndex_GetName(t *testing.T) {
+	tests := []struct {
+		name      string
+		indexName string
+		want      string
+	}{
+		{
+			indexName: "test_index",
+			want: "test_index",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Index{
+				name: tt.indexName,
+			}
+			if got := i.GetName(); got != tt.want {
+				t.Errorf("GetName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #663 
| Need Doc update   |no


## Describe your change
Made it possible to get index name from `Index` interface.

## What problem is this fixing?
this library's user can get index name and use it for logging and so on.