### PR TITLE
feat(QueryRes): add support for unknown fields

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -36,6 +36,7 @@ type QueryRes struct {
 	TimeoutHits           bool                              `json:"timeoutHits"`
 	UserData              []interface{}                     `json:"userData"`
 	ABTestVariantID       int                               `json:"abTestVariantID"`
+	UnknownFields         map[string]interface{}            `json:"-"`
 }
 
 type AppliedRule struct {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     |
| Need Doc update   | no


## Describe your change

Add support for unknown fields in the query response using the special `-` case of `json.Unmarshal`.

## What problem is this fixing?

In order to debug new fields in the response before support is added in API clients, exposing the unknown fields of the response object would be useful.
