### PR TITLE
chore: Rename recommendation package to personalization package

### DIFF
--- a/algolia/personalization/client.go
+++ b/algolia/personalization/client.go
@@ -1,4 +1,4 @@
-package recommendation
+package personalization
 
 import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
@@ -7,13 +7,11 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
-// Deprecated: use personalization.Client instead
 // Client provides methods to interact with the Algolia Recommendation API.
 type Client struct {
 	transport *transport.Transport
 }
 
-// Deprecated: use personalization.NewClient() instead
 // NewClient instantiates a new client able to interact with the Algolia
 // Recommendation API.
 func NewClient(appID, apiKey string, region region.Region) *Client {

--- a/algolia/personalization/client_personalization.go
+++ b/algolia/personalization/client_personalization.go
@@ -1,0 +1,24 @@
+package personalization
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+)
+
+func (c *Client) GetPersonalizationStrategy(opts ...interface{}) (strategy Strategy, err error) {
+	path := c.pathPersonalization("")
+	err = c.transport.Request(&strategy, http.MethodGet, path, nil, call.Read)
+	return
+}
+
+func (c *Client) SetPersonalizationStrategy(strategy Strategy, opts ...interface{}) (res SetPersonalizationStrategyRes, err error) {
+	path := c.pathPersonalization("")
+	err = c.transport.Request(&strategy, http.MethodPost, path, strategy, call.Write)
+	return
+}
+
+func (c *Client) pathPersonalization(format string, a ...interface{}) string {
+	return "/1/strategies/personalization" + fmt.Sprintf(format, a...)
+}

--- a/algolia/personalization/configuration.go
+++ b/algolia/personalization/configuration.go
@@ -1,4 +1,4 @@
-package recommendation
+package personalization
 
 import (
 	"time"
@@ -7,7 +7,6 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
 )
 
-// Deprecated: use personalization.Configuration instead
 type Configuration struct {
 	AppID          string
 	APIKey         string

--- a/algolia/personalization/responses_personalization.go
+++ b/algolia/personalization/responses_personalization.go
@@ -1,0 +1,6 @@
+package personalization
+
+type SetPersonalizationStrategyRes struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}

--- a/algolia/personalization/types_personalization.go
+++ b/algolia/personalization/types_personalization.go
@@ -1,0 +1,20 @@
+package personalization
+
+import "github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
+
+type Strategy struct {
+	EventsScoring         []EventsScoring                  `json:"eventsScoring"`
+	FacetsScoring         []FacetsScoring                  `json:"facetsScoring"`
+	PersonalizationImpact *opt.PersonalizationImpactOption `json:"personalizationImpact"`
+}
+
+type EventsScoring struct {
+	EventName string `json:"eventName"`
+	EventType string `json:"eventType"`
+	Score     int    `json:"score"`
+}
+
+type FacetsScoring struct {
+	FacetName string `json:"facetName"`
+	Score     int    `json:"score"`
+}

--- a/algolia/personalization/utils.go
+++ b/algolia/personalization/utils.go
@@ -1,0 +1,19 @@
+package personalization
+
+import (
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/call"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/transport"
+)
+
+func defaultHosts(r region.Region) (hosts []*transport.StatefulHost) {
+	switch r {
+	case region.EU, region.US:
+		hosts = append(hosts, transport.NewStatefulHost(fmt.Sprintf("recommendation.%s.algolia.com", r), call.IsReadWrite))
+	default:
+		hosts = append(hosts, transport.NewStatefulHost("recommendation.us.algolia.com", call.IsReadWrite))
+	}
+	return
+}

--- a/algolia/recommendation/client.go
+++ b/algolia/recommendation/client.go
@@ -26,6 +26,7 @@ func NewClient(appID, apiKey string, region region.Region) *Client {
 	)
 }
 
+// Deprecated: use personalization.NewClientWithConfig() instead
 // NewClientWithConfig instantiates a new client able to interact with the
 // Recommendation API.
 func NewClientWithConfig(config Configuration) *Client {

--- a/cts/recommendation/personalization_strategy_test.go
+++ b/cts/recommendation/personalization_strategy_test.go
@@ -1,4 +1,4 @@
-package recommendation
+package personalization
 
 import (
 	"testing"
@@ -7,19 +7,19 @@ import (
 
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/errs"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
-	"github.com/algolia/algoliasearch-client-go/v3/algolia/recommendation"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/personalization"
 	"github.com/algolia/algoliasearch-client-go/v3/cts"
 )
 
 func TestPersonalizationStrategy(t *testing.T) {
-	client := cts.InitRecommendationClient(t)
+	client := cts.InitPersonalizationClient(t)
 
-	strategy := recommendation.Strategy{
-		EventsScoring: []recommendation.EventsScoring{
+	strategy := personalization.Strategy{
+		EventsScoring: []personalization.EventsScoring{
 			{EventName: "Add to cart", EventType: "conversion", Score: 50},
 			{EventName: "Purchase", EventType: "conversion", Score: 100},
 		},
-		FacetsScoring: []recommendation.FacetsScoring{
+		FacetsScoring: []personalization.FacetsScoring{
 			{FacetName: "brand", Score: 100},
 			{FacetName: "categories", Score: 10},
 		},

--- a/cts/testing_utils.go
+++ b/cts/testing_utils.go
@@ -18,7 +18,7 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/analytics"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/compression"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/insights"
-	"github.com/algolia/algoliasearch-client-go/v3/algolia/recommendation"
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/personalization"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/region"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/suggestions"
@@ -74,8 +74,8 @@ func InitInsightsClient(t *testing.T) *insights.Client {
 	return initInsightsClientWith(t, "ALGOLIA_APPLICATION_ID_1", "ALGOLIA_ADMIN_KEY_1")
 }
 
-func InitRecommendationClient(t *testing.T) *recommendation.Client {
-	return initRecommendationClientWith(t, "ALGOLIA_APPLICATION_ID_1", "ALGOLIA_ADMIN_KEY_1")
+func InitPersonalizationClient(t *testing.T) *personalization.Client {
+	return initPersonalizationClientWith(t, "ALGOLIA_APPLICATION_ID_1", "ALGOLIA_ADMIN_KEY_1")
 }
 
 func InitQuerySuggestionsClient1(t *testing.T) *suggestions.Client {
@@ -105,9 +105,9 @@ func initAnalyticsClientWith(t *testing.T, appIDEnvVar, apiKeyEnvVar string) *an
 	return c
 }
 
-func initRecommendationClientWith(t *testing.T, appIDEnvVar, apiKeyEnvVar string) *recommendation.Client {
+func initPersonalizationClientWith(t *testing.T, appIDEnvVar, apiKeyEnvVar string) *personalization.Client {
 	appID, key := GetTestingCredentials(t, appIDEnvVar, apiKeyEnvVar)
-	c := recommendation.NewClient(appID, key, region.US)
+	c := personalization.NewClient(appID, key, region.US)
 	return c
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #665 
| Need Doc update   | yes


## Describe your change

This PR renames the recommendation package to personalization, keeping the recommendation package deprecated.

## What problem is this fixing?

Fix #665 