### PR TITLE
fix: Make Index.Exists() return error if the error is not not-found error

### DIFF
--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -106,10 +106,11 @@ func (i *Index) GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes,
 // with false.
 func (i *Index) Exists() (bool, error) {
 	_, err := i.GetSettings()
-	_, ok := errs.IsAlgoliaErr(err)
-	if !ok && err != nil {
-		return false, err
+	if err == nil {
+		return true, nil
 	}
-	_, ok = errs.IsAlgoliaErrWithCode(err, http.StatusNotFound)
-	return !ok, nil
+	if _, ok := errs.IsAlgoliaErrWithCode(err, http.StatusNotFound); ok {
+		return false, nil
+	}
+	return false, err
 }

--- a/cts/index/exists_test.go
+++ b/cts/index/exists_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"testing"
 
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 	"github.com/algolia/algoliasearch-client-go/v3/cts"
 	"github.com/stretchr/testify/require"
 )
@@ -23,4 +24,8 @@ func TestExists(t *testing.T) {
 	ok, _ = index.Exists()
 	require.True(t, ok)
 	require.NoError(t, err)
+
+	ok, err = search.NewClient(index.GetAppID(), "invalid").InitIndex(index.GetName()).Exists()
+	require.False(t, ok)
+	require.Error(t, err)
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #672  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change
Fix index.Exists() to return error if the error is not not-found error.

## What problem is this fixing?
#672