### PR TITLE
feat(RenderingContent): Add the rendering content as a settings field

### DIFF
--- a/algolia/internal/gen/templates/settings.go.tmpl
+++ b/algolia/internal/gen/templates/settings.go.tmpl
@@ -16,7 +16,7 @@ type Settings struct {
     {{- range $_, $setting := . }}
     {{ title $setting.Name }} *opt.{{ title $setting.Name }}Option `json:"{{ $setting.Name }},omitempty"`
     {{- end }}
-    RenderingContent *RenderingContent `json:"renderingContent"`
+    RenderingContent *RenderingContent `json:"renderingContent,omitempty"`
     CustomSettings map[string]interface{} `json:"-"`
 }
 

--- a/algolia/internal/gen/templates/settings.go.tmpl
+++ b/algolia/internal/gen/templates/settings.go.tmpl
@@ -16,6 +16,7 @@ type Settings struct {
     {{- range $_, $setting := . }}
     {{ title $setting.Name }} *opt.{{ title $setting.Name }}Option `json:"{{ $setting.Name }},omitempty"`
     {{- end }}
+    RenderingContent *RenderingContent `json:"renderingContent"`
     CustomSettings map[string]interface{} `json:"-"`
 }
 
@@ -104,6 +105,8 @@ func (s Settings) String() string {
     {{- range $_, $setting := . }}
     settingsStr += fmt.Sprintf("\t{{ title $setting.Name }}: %v,\n", stringifyReturnValues(s.{{ title $setting.Name }}.Get()))
     {{- end }}
+
+    settingsStr += fmt.Sprintf("\tRenderingContent: %+v\n", s.RenderingContent)
 
     settingsStr += "\tCustomSettings{\n"
     for k, v := range s.CustomSettings {

--- a/algolia/search/rendering_content.go
+++ b/algolia/search/rendering_content.go
@@ -30,6 +30,10 @@ type FacetValuesOrder struct {
 	SortRemainingBy *SortRule `json:"sortRemainingBy"`
 }
 
+func NewFacetValuesOrder(order []string, sortRemainingBy SortRule) FacetValuesOrder {
+	return FacetValuesOrder{Order: order, SortRemainingBy: &sortRemainingBy}
+}
+
 // Rule defining the sort order of facet values.
 type SortRule string
 

--- a/algolia/search/rendering_content_test.go
+++ b/algolia/search/rendering_content_test.go
@@ -34,3 +34,21 @@ func TestUnmarshalRenderingContent(t *testing.T) {
 	require.Equal(t, r.FacetOrdering.Values["color"].Order, []string{"red", "green"})
 	require.Nil(t, r.FacetOrdering.Values["color"].SortRemainingBy)
 }
+
+func TestBuildRenderingContent(t *testing.T) {
+
+	var r = RenderingContent{FacetOrdering: &FacetOrdering{
+		Facets: &FacetsOrder{Order: []string{"size", "brand"}},
+		Values: map[string]FacetValuesOrder{
+			"brand": NewFacetValuesOrder([]string{"Uniqlo"}, Count),
+			"size":  NewFacetValuesOrder([]string{"S", "M", "L"}, Hidden),
+		},
+	}}
+
+	require.Equal(t, r.FacetOrdering.Facets.Order, []string{"size", "brand"})
+	require.Equal(t, r.FacetOrdering.Values["brand"].Order, []string{"Uniqlo"})
+	require.Equal(t, *r.FacetOrdering.Values["brand"].SortRemainingBy, Count)
+	require.Equal(t, r.FacetOrdering.Values["size"].Order, []string{"S", "M", "L"})
+	require.Equal(t, *r.FacetOrdering.Values["size"].SortRemainingBy, Hidden)
+
+}

--- a/algolia/search/settings.go
+++ b/algolia/search/settings.go
@@ -73,6 +73,7 @@ type Settings struct {
 	Advanced                                *opt.AdvancedOption                                `json:"advanced,omitempty"`
 	AttributeCriteriaComputedByMinProximity *opt.AttributeCriteriaComputedByMinProximityOption `json:"attributeCriteriaComputedByMinProximity,omitempty"`
 	UserData                                *opt.UserDataOption                                `json:"userData,omitempty"`
+	RenderingContent                        *RenderingContent                                  `json:"renderingContent"`
 	CustomSettings                          map[string]interface{}                             `json:"-"`
 }
 
@@ -511,6 +512,8 @@ func (s Settings) String() string {
 	settingsStr += fmt.Sprintf("\tAdvanced: %v,\n", stringifyReturnValues(s.Advanced.Get()))
 	settingsStr += fmt.Sprintf("\tAttributeCriteriaComputedByMinProximity: %v,\n", stringifyReturnValues(s.AttributeCriteriaComputedByMinProximity.Get()))
 	settingsStr += fmt.Sprintf("\tUserData: %v,\n", stringifyReturnValues(s.UserData.Get()))
+
+	settingsStr += fmt.Sprintf("\tRenderingContent: %+v\n", *s.RenderingContent)
 
 	settingsStr += "\tCustomSettings{\n"
 	for k, v := range s.CustomSettings {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

- Add the `RenderingContent` as a Settings field.
- Add a convenient `FacetValuesOrder` constructor