### PR TITLE
fix: Suppress rule condition pattern marshalling in case of empty anchoring

### DIFF
--- a/algolia/search/rule_condition.go
+++ b/algolia/search/rule_condition.go
@@ -12,7 +12,7 @@ type RuleCondition struct {
 
 func (c RuleCondition) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
-	if c.Anchoring != "" || c.Pattern != "" {
+	if c.Anchoring != "" {
 		m["anchoring"] = c.Anchoring
 		m["pattern"] = c.Pattern
 	}

--- a/algolia/search/rule_condition_test.go
+++ b/algolia/search/rule_condition_test.go
@@ -44,7 +44,7 @@ func TestRuleCondition_MarshalJSON(t *testing.T) {
 				Alternatives: nil,
 				Filters:      "",
 			},
-			`{"anchoring": "", "pattern": "Pattern"}`,
+			`{}`,
 		},
 		{
 			RuleCondition{
@@ -106,7 +106,11 @@ func TestRuleCondition_MarshalJSON(t *testing.T) {
 
 		// Compare the two RuleConditions
 		require.Equal(t, c.condition.Anchoring, condition.Anchoring)
-		require.Equal(t, c.condition.Pattern, condition.Pattern)
+		if c.condition.Anchoring == "" {
+			require.Equal(t, condition.Pattern, "")
+		} else {
+			require.Equal(t, c.condition.Pattern, condition.Pattern)
+		}
 		require.Equal(t, c.condition.Context, condition.Context)
 		if c.condition.Alternatives == nil {
 			require.Nil(t, condition.Alternatives)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

The engine doesn't accept Query Rule condition pattern in case of missing `anchoring` parameter. 
This PR suppress `pattern` parameter marshalling if the anchoring parameter is empty. 
