### PR TITLE
fix: Suggestion config bool value support

### DIFF
--- a/algolia/suggestions/bool_or_string_array.go
+++ b/algolia/suggestions/bool_or_string_array.go
@@ -1,0 +1,52 @@
+package suggestions
+
+import "encoding/json"
+
+// BoolOrStringArray can hold either a bool or a []string.
+// IsBool indicates the valid value: Bool or StringArray.
+type BoolOrStringArray struct {
+	IsBool      bool
+	Bool        bool
+	StringArray []string
+}
+
+func NewBool(boolValue bool) BoolOrStringArray {
+	return BoolOrStringArray{
+		IsBool:      true,
+		Bool:        boolValue,
+		StringArray: []string{},
+	}
+}
+
+func NewStringArray(array []string) BoolOrStringArray {
+	return BoolOrStringArray{
+		IsBool:      false,
+		Bool:        false,
+		StringArray: array,
+	}
+}
+
+// UnmarshalJSON decodes a JSON bool or string array into a BoolOrStringArray.
+func (b *BoolOrStringArray) UnmarshalJSON(data []byte) error {
+	err := json.Unmarshal(data, &b.Bool)
+	if err == nil {
+		b.IsBool = true
+		b.StringArray = []string{}
+		return nil
+	}
+	err = json.Unmarshal(data, &b.StringArray)
+	if err == nil {
+		b.IsBool = false
+		b.Bool = false
+		return nil
+	}
+	return err
+}
+
+// MarshalJSON encodes a BoolOrStringArray to a JSON bool or string array.
+func (b BoolOrStringArray) MarshalJSON() ([]byte, error) {
+	if b.IsBool {
+		return json.Marshal(b.Bool)
+	}
+	return json.Marshal(b.StringArray)
+}

--- a/algolia/suggestions/client_config.go
+++ b/algolia/suggestions/client_config.go
@@ -15,7 +15,7 @@ type IndexConfiguration struct {
 	// De-duplicate singular and plural suggestions. Can be either a list languages []string or a boolean.
 	// true value means that all the languages are supported.
 	// false value means that singulars and plurals are not considered the same for matching purposes (foot will not find feet).
-	// []string a list of language ISO codes for which singualr and plural suggestions should be enabled.
+	// []string a list of language ISO codes for which singular and plural suggestions should be enabled.
 	Languages BoolOrStringArray `json:"languages,omitempty"`
 	// List of words and patterns to exclude from the Query Suggestions index.
 	Exclude []string `json:"exclude,omitempty"`

--- a/algolia/suggestions/client_config.go
+++ b/algolia/suggestions/client_config.go
@@ -16,7 +16,7 @@ type IndexConfiguration struct {
 	// true value means that all the languages are supported.
 	// false value means that singulars and plurals are not considered the same for matching purposes (foot will not find feet).
 	// []string a list of language ISO codes for which singular and plural suggestions should be enabled.
-	Languages BoolOrStringArray `json:"languages,omitempty"`
+	Languages BoolOrStringArray `json:"languages"`
 	// List of words and patterns to exclude from the Query Suggestions index.
 	Exclude []string `json:"exclude,omitempty"`
 }

--- a/algolia/suggestions/client_config.go
+++ b/algolia/suggestions/client_config.go
@@ -12,8 +12,11 @@ type IndexConfiguration struct {
 	IndexName string `json:"indexName"`
 	// List of source indices used to generate a Query Suggestions index.
 	SourceIndices []SourceIndex `json:"sourceIndices"`
-	// De-duplicate singular and plural suggestions.
-	Languages []string `json:"languages,omitempty"`
+	// De-duplicate singular and plural suggestions. Can be either a list languages []string or a boolean.
+	// true value means that all the languages are supported.
+	// false value means that singulars and plurals are not considered the same for matching purposes (foot will not find feet).
+	// []string a list of language ISO codes for which singualr and plural suggestions should be enabled.
+	Languages BoolOrStringArray `json:"languages,omitempty"`
 	// List of words and patterns to exclude from the Query Suggestions index.
 	Exclude []string `json:"exclude,omitempty"`
 }

--- a/algolia/suggestions/client_config_test.go
+++ b/algolia/suggestions/client_config_test.go
@@ -1,0 +1,37 @@
+package suggestions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Unmarshal(t *testing.T) {
+	var c IndexConfiguration
+	data := []byte(`{"languages":["ja"]}`)
+	err := json.Unmarshal(data, &c)
+	require.NoError(t, err)
+	require.False(t, c.Languages.IsBool)
+	require.Equal(t, []string{"ja"}, c.Languages.StringArray)
+
+	c = IndexConfiguration{}
+	data = []byte(`{"languages":false}`)
+	err = json.Unmarshal(data, &c)
+	require.NoError(t, err)
+	require.False(t, c.Languages.Bool)
+
+	c = IndexConfiguration{}
+	data = []byte(`{}`)
+	err = json.Unmarshal(data, &c)
+	require.NoError(t, err)
+	require.False(t, c.Languages.IsBool)
+}
+
+func TestConfig_Marshal(t *testing.T) {
+	config := IndexConfiguration{
+		IndexName: "my_index",
+	}
+	json, _ := json.Marshal(config)
+	t.Log(string(json))
+}

--- a/algolia/suggestions/client_config_test.go
+++ b/algolia/suggestions/client_config_test.go
@@ -27,11 +27,3 @@ func TestConfig_Unmarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, c.Languages.IsBool)
 }
-
-func TestConfig_Marshal(t *testing.T) {
-	config := IndexConfiguration{
-		IndexName: "my_index",
-	}
-	json, _ := json.Marshal(config)
-	t.Log(string(json))
-}

--- a/cts/suggestions/config_test.go
+++ b/cts/suggestions/config_test.go
@@ -45,7 +45,7 @@ func TestConfig(t *testing.T) {
 				Generate:      nil,
 			},
 		},
-		Languages: []string{"en"},
+		Languages: suggestions.NewStringArray([]string{"en"}),
 		Exclude:   nil,
 	}
 
@@ -61,7 +61,7 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("Update the query suggestion index", func(t *testing.T) {
-		indexConfig.Languages = []string{"ja"}
+		indexConfig.Languages = suggestions.NewStringArray([]string{"ja"})
 		err := querySuggestionsClient.UpdateConfig(indexConfig)
 		require.NoError(t, err)
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes/no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #671 
| Need Doc update   | no


## Describe your change

This PR introduces `BoolOrStringArray` type to properly represent the query suggestions configuration `languages` value.

## What problem is this fixing?

Described in #671