### PR TITLE
Allow for SSL to be disabled so we can make non-HTTPS requests

### DIFF
--- a/algolia/analytics/client.go
+++ b/algolia/analytics/client.go
@@ -61,6 +61,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			compression.None,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/analytics/configuration.go
+++ b/algolia/analytics/configuration.go
@@ -19,4 +19,5 @@ type Configuration struct {
 	Region         region.Region
 	Headers        map[string]string
 	ExtraUserAgent string
+	DisableSSL     bool
 }

--- a/algolia/insights/client.go
+++ b/algolia/insights/client.go
@@ -50,6 +50,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			compression.None,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/insights/configuration.go
+++ b/algolia/insights/configuration.go
@@ -19,4 +19,5 @@ type Configuration struct {
 	Region         region.Region
 	Headers        map[string]string
 	ExtraUserAgent string
+	DisableSSL     bool
 }

--- a/algolia/personalization/client.go
+++ b/algolia/personalization/client.go
@@ -48,6 +48,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			compression.None,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/personalization/configuration.go
+++ b/algolia/personalization/configuration.go
@@ -17,4 +17,5 @@ type Configuration struct {
 	Region         region.Region
 	Headers        map[string]string
 	ExtraUserAgent string
+	DisableSSL     bool
 }

--- a/algolia/recommend/client.go
+++ b/algolia/recommend/client.go
@@ -47,6 +47,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			config.Compression,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/recommend/configuration.go
+++ b/algolia/recommend/configuration.go
@@ -19,4 +19,5 @@ type Configuration struct {
 	Headers        map[string]string
 	ExtraUserAgent string
 	Compression    compression.Compression
+	DisableSSL     bool
 }

--- a/algolia/recommendation/client.go
+++ b/algolia/recommendation/client.go
@@ -51,6 +51,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			compression.None,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/recommendation/configuration.go
+++ b/algolia/recommendation/configuration.go
@@ -18,4 +18,5 @@ type Configuration struct {
 	Region         region.Region
 	Headers        map[string]string
 	ExtraUserAgent string
+	DisableSSL     bool
 }

--- a/algolia/search/client.go
+++ b/algolia/search/client.go
@@ -73,6 +73,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			config.Compression,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/search/configuration.go
+++ b/algolia/search/configuration.go
@@ -20,4 +20,5 @@ type Configuration struct {
 	Headers        map[string]string
 	ExtraUserAgent string
 	Compression    compression.Compression
+	DisableSSL     bool
 }

--- a/algolia/suggestions/client.go
+++ b/algolia/suggestions/client.go
@@ -63,6 +63,7 @@ func NewClientWithConfig(config Configuration) *Client {
 			config.Headers,
 			config.ExtraUserAgent,
 			compression.None,
+			config.DisableSSL,
 		),
 	}
 }

--- a/algolia/suggestions/configuration.go
+++ b/algolia/suggestions/configuration.go
@@ -19,4 +19,5 @@ type Configuration struct {
 	Region         region.Region
 	Headers        map[string]string
 	ExtraUserAgent string
+	DisableSSL     bool
 }

--- a/algolia/transport/transport_test.go
+++ b/algolia/transport/transport_test.go
@@ -55,6 +55,7 @@ func TestShouldNotExposeIntermediateNetworkErrors(t *testing.T) {
 		nil,
 		"",
 		compression.None,
+		false,
 	)
 	var res string
 	err := transporter.Request(&res, http.MethodGet, "", nil, call.Read)
@@ -74,6 +75,7 @@ func TestShouldExposeIntermediateNetworkErrors(t *testing.T) {
 		nil,
 		"",
 		compression.None,
+		false,
 	)
 	opts := []interface{}{opt.ExposeIntermediateNetworkErrors(true)}
 	var res string
@@ -143,6 +145,7 @@ func TestOnNetworkErrorWithNilBody(t *testing.T) {
 		nil,
 		"",
 		compression.None,
+		false,
 	)
 
 	opts := []interface{}{opt.ExposeIntermediateNetworkErrors(true)}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

In this PR, we're adding the ability to disable SSL for outgoing requests, to every configuration struct used to instantiate a particular client. This means that, if `DisableSSL` is set to true on the configuration struct, an `http://` request will be made to the target algolia server, rather than an `https://` request.

## What problem is this fixing?

I want to test parts of my application, of which algolia is a dependency. I found it difficult to create a mock algolia client, so I decided instead to run a mock algolia server implementation, and create a real client in my code that connects to it. The mock implementation I'm using is https://github.com/davesag/mock-algolia. When I run this implementation in docker container, the service runs over `http`, rather than `https`, so, when my test client connects to the docker instance, I get the following intermediate network error:

`http: server gave HTTP response to HTTPS client`

I noticed that, in the mock algolia server repo, it looks as though the Javascript implementation of the algolia client allows you to specify a `http://` scheme, but this doesn't look to be the case for the Go implementation. 

I thought it would be a nice to have `https` as the default scheme, but also allow for `http` if desired. 

Running with this change in place lets me make successful requests to the mock algolia instance in my tests.