### PR TITLE
access GenerateSecuredAPIKey function using the client

### DIFF
--- a/algolia/search/generate_secured_api_key.go
+++ b/algolia/search/generate_secured_api_key.go
@@ -24,7 +24,7 @@ import (
 //
 // More details here:
 // https://www.algolia.com/doc/api-reference/api-methods/generate-secured-api-key/?language=python#parameters
-func GenerateSecuredAPIKey(apiKey string, opts ...interface{}) (string, error) {
+func (c *Client) GenerateSecuredAPIKey(apiKey string, opts ...interface{}) (string, error) {
 	h := hmac.New(sha256.New, []byte(apiKey))
 
 	message := transport.URLEncode(newSecuredAPIKeyParams(opts...))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no  
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes/no


## Describe your change


## What problem is this fixing?

Currently, you can't access `GenerateSecuredAPIKey` function using the client.
