### PR TITLE
chore(circleci): split unit/integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ commands:
               curl -s https://algoliasearch-client-keygen.herokuapp.com | sh >> $BASH_ENV
             fi
 
-  test:
-    description: "Run the test for Go << parameters.go_version >>"
+  unit-tests:
+    description: "Run the unit tests for Go << parameters.go_version >>"
     parameters:
       go_version:
         type: string
@@ -23,8 +23,18 @@ commands:
       - run:
           name: Run unit tests for Go << parameters.go_version >>
           command: make unit-tests
+
+  integration-tests:
+    description: "Run the integration tests for Go << parameters.go_version >>"
+    parameters:
+      go_version:
+        type: string
+    steps:
       - run:
-          name: Run tests for Go << parameters.go_version >>
+          name: Generate code for Go << parameters.go_version >>
+          command: go generate ./...
+      - run:
+          name: Run integration tests for Go << parameters.go_version >>
           command: |
             if [ -z "ALGOLIA_ADMIN_KEY_MCM" ]; then
               make integration-tests-community
@@ -47,7 +57,24 @@ jobs:
           name: Check formatting
           command: make lint
 
-  test:
+  unit-tests:
+    parameters:
+        go_version:
+          type: string
+    docker:
+      - image: cimg/go:<< parameters.go_version >>
+    steps:
+      - checkout
+      - restore_cache:
+          key: go-cache-<< parameters.go_version >>
+      - unit-tests:
+          go_version: "<< parameters.go_version >>"
+      - save_cache:
+          key: go-cache-<< parameters.go_version >>
+          paths:
+            - "~/go/pkg"
+
+  integration-tests:
     parameters:
         go_version:
           type: string
@@ -58,7 +85,7 @@ jobs:
       - restore_cache:
           key: go-cache-<< parameters.go_version >>
       - credentials
-      - test:
+      - integration-tests:
           go_version: "<< parameters.go_version >>"
       - save_cache:
           key: go-cache-<< parameters.go_version >>
@@ -69,7 +96,18 @@ workflows:
   build:
     jobs:
       - format
-      - test:
+
+      - unit-tests:
+          matrix:
+              parameters:
+                go_version:
+                    - "1.13"
+                    - "1.14"
+                    - "1.15"
+                    - "1.16"
+                    - "1.17"
+
+      - integration-tests:
           matrix:
               parameters:
                 go_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             - "~/go/pkg"
 
 workflows:
-  build:
+  ci:
     jobs:
       - format
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,11 @@ workflows:
                     - "1.17"
 
       - integration-tests:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+              ignore: /pull\/[0-9]+/
           matrix:
               parameters:
                 go_version:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no   
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

This PR split the unit tests and the integration tests in CircleCI into dedicated jobs: `unit-tests` & `integration-tests`.

## What problem is this fixing?

The `integrations-tests` require credentials, and those credentials are **NOT** forwarded to fork pull requests. It means that **ALL** pull requests made by any external contributor is failing from the CI point of view. The idea is to disable the integrations tests suite on fork pull request because anyway they won't pass (see [CircleCI documentation](https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/)).

## Next steps

We have to change the required checks from `test-1.XX` to ` unit-tests-1.XX`. The integration tests become optional but since they cannot run on every PRs anyway it makes no sense to have them required. If they are failing it's our responsibility to check the output.