### PR TITLE
fix(search) hits in search response are now marshalled as 'hits'

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -17,7 +17,7 @@ type QueryRes struct {
 	Extensions                 map[string]map[string]interface{} `json:"extensions"`
 	Facets                     map[string]map[string]int         `json:"facets"`
 	FacetsStats                map[string]FacetStat              `json:"facets_stats"`
-	Hits                       []map[string]interface{}          `json:"Hits"`
+	Hits                       []map[string]interface{}          `json:"hits"`
 	HitsPerPage                int                               `json:"hitsPerPage"`
 	Index                      string                            `json:"index"`
 	IndexUsed                  string                            `json:"indexUsed"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | None
| Need Doc update   | no


## Describe your change

The `hits` property in a search response (`QueryRes`) is now marshalled as `hits` instead of `Hits`.

## What problem is this fixing?

The `hits` property in a search response (`QueryRes`) was marshalled as `Hits` instead of `hits`, which breaks an integration with InstantSearch in a back-end search implementation. The JS client requires `hits`.
