### PR TITLE
feat(index): add options to index.exists function

### DIFF
--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -104,8 +104,8 @@ func (i *Index) GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes,
 // Exists returns whether an initialized index exists or not, along with a nil
 // error. When encountering a network error, a non-nil error is returned along
 // with false.
-func (i *Index) Exists() (bool, error) {
-	_, err := i.GetSettings()
+func (i *Index) Exists(opts ...interface{}) (bool, error) {
+	_, err := i.GetSettings(opts...)
 	if err == nil {
 		return true, nil
 	}

--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -10,7 +10,7 @@ type IndexInterface interface {
 	GetName() string
 	ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error)
 	Delete(opts ...interface{}) (res DeleteTaskRes, err error)
-	Exists() (exists bool, err error)
+	Exists(opts ...interface{}) (exists bool, err error)
 
 	// Indexing
 	GetObject(objectID string, object interface{}, opts ...interface{}) error


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no   (improve an existing function)
| BC breaks?        | no     
| Related Issue     | Fix #710
| Need Doc update   | no


## Describe your change

Currently the function `index.Exists` doesn't accept options like other functions.

Options can be used to propagate the context, for example to do tracing. The goal of this commit is to add `opts` to `index.exists`

## What problem is this fixing?

Propagate opts to others functions call by `Exists` function
