### PR TITLE
fix(search): Add abTestID to search response

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -39,6 +39,8 @@ type QueryRes struct {
 	TimeoutHits                bool                              `json:"timeoutHits"`
 	UserData                   []interface{}                     `json:"userData"`
 	ABTestVariantID            int                               `json:"abTestVariantID"`
+	ABTestID                   uint32                            `json:"abTestID"`
+	ABTestIndex                string                            `json:"abTestIndex"`
 	RenderingContent           *RenderingContent                 `json:"renderingContent"`
 }
 

--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -40,7 +40,6 @@ type QueryRes struct {
 	UserData                   []interface{}                     `json:"userData"`
 	ABTestVariantID            int                               `json:"abTestVariantID"`
 	ABTestID                   uint32                            `json:"abTestID"`
-	ABTestIndex                string                            `json:"abTestIndex"`
 	RenderingContent           *RenderingContent                 `json:"renderingContent"`
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

`abTestID` is not currently returned from the client, even though it's a [documented value](https://www.algolia.com/doc/api-reference/api-methods/search/#method-response-abtestid)

This was handled in some of the other clients in the past. e.g. [javascript](https://github.com/algolia/algoliasearch-client-javascript/commit/05059f2)

## What problem is this fixing?

Returning the value from search responses when the value exists
