### PR TITLE
fix(search) handle automaticFacetFilters unmarshal from string

### DIFF
--- a/algolia/search/rule_consequence_params.go
+++ b/algolia/search/rule_consequence_params.go
@@ -80,6 +80,45 @@ type AutomaticFacetFilter struct {
 	Score       int    `json:"score"`       // Defaults to 1
 }
 
+// AutomaticFacetFilter can be unmarshalled from a string or an object.
+func (a *AutomaticFacetFilter) UnmarshalJSON(data []byte) error {
+	if string(data) == jsonNull {
+		return nil
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	switch data[0] {
+	case '"':
+		var facet string
+		if err := json.Unmarshal(data, &facet); err != nil {
+			return err
+		}
+		*a = AutomaticFacetFilter{
+			Facet: facet,
+		}
+		return nil
+	case '{':
+		var alias struct {
+			Facet       string `json:"facet"`
+			Disjunctive bool   `json:"disjunctive"`
+			Score       int    `json:"score"`
+		}
+		if err := json.Unmarshal(data, &alias); err != nil {
+			return err
+		}
+		*a = AutomaticFacetFilter{
+			Facet:       alias.Facet,
+			Disjunctive: alias.Disjunctive,
+			Score:       alias.Score,
+		}
+		return nil
+	}
+	return fmt.Errorf("cannot unmarshal automatic facet filter")
+}
+
 type QueryEdit struct {
 	Type   QueryEditType `json:"type"`
 	Delete string        `json:"delete"`

--- a/algolia/search/rule_consequence_params.go
+++ b/algolia/search/rule_consequence_params.go
@@ -82,11 +82,11 @@ type AutomaticFacetFilter struct {
 
 // AutomaticFacetFilter can be unmarshalled from a string or an object.
 func (a *AutomaticFacetFilter) UnmarshalJSON(data []byte) error {
-	if string(data) == jsonNull {
+	if len(data) == 0 {
 		return nil
 	}
 
-	if len(data) == 0 {
+	if string(data) == jsonNull {
 		return nil
 	}
 
@@ -115,8 +115,9 @@ func (a *AutomaticFacetFilter) UnmarshalJSON(data []byte) error {
 			Score:       alias.Score,
 		}
 		return nil
+	default:
+		return fmt.Errorf("cannot unmarshal automatic facet filter")
 	}
-	return fmt.Errorf("cannot unmarshal automatic facet filter")
 }
 
 type QueryEdit struct {

--- a/algolia/search/rule_consequence_params_test.go
+++ b/algolia/search/rule_consequence_params_test.go
@@ -7,26 +7,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_AutomaticFacetFilter_UnMarshalJSON(t *testing.T) {
+func Test_AutomaticFacetFilter_UnmarshalJSON(t *testing.T) {
 	for _, c := range []struct {
 		input    string
 		expected AutomaticFacetFilter
+		err      string
 	}{
 		{
-			`{"facet": "facet", "score": 42}`,
-			AutomaticFacetFilter{Facet: "facet", Score: 42},
+			input:    `{"facet": "facet", "score": 42}`,
+			expected: AutomaticFacetFilter{Facet: "facet", Score: 42},
 		},
 		{
-			`{"facet": "facet", "score": 42, "disjunctive": true}`,
-			AutomaticFacetFilter{Facet: "facet", Score: 42, Disjunctive: true},
+			input:    `{"facet": "facet", "score": 42, "disjunctive": true}`,
+			expected: AutomaticFacetFilter{Facet: "facet", Score: 42, Disjunctive: true},
 		},
 		{
-			`"facet"`,
-			AutomaticFacetFilter{Facet: "facet"},
+			input:    `"facet"`,
+			expected: AutomaticFacetFilter{Facet: "facet"},
+		},
+		{
+			input: `[]`,
+			err:   `cannot unmarshal automatic facet filter`,
 		},
 	} {
 		var actual AutomaticFacetFilter
 		err := json.Unmarshal([]byte(c.input), &actual)
+		if c.err != "" {
+			require.EqualError(t, err, c.err)
+			continue
+		}
 		require.NoError(t, err)
 		require.Equal(t, c.expected, actual)
 	}

--- a/algolia/search/rule_consequence_params_test.go
+++ b/algolia/search/rule_consequence_params_test.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AutomaticFacetFilter_UnMarshalJSON(t *testing.T) {
+	for _, c := range []struct {
+		input    string
+		expected AutomaticFacetFilter
+	}{
+		{
+			`{"facet": "facet", "score": 42}`,
+			AutomaticFacetFilter{Facet: "facet", Score: 42},
+		},
+		{
+			`{"facet": "facet", "score": 42, "disjunctive": true}`,
+			AutomaticFacetFilter{Facet: "facet", Score: 42, Disjunctive: true},
+		},
+		{
+			`"facet"`,
+			AutomaticFacetFilter{Facet: "facet"},
+		},
+	} {
+		var actual AutomaticFacetFilter
+		err := json.Unmarshal([]byte(c.input), &actual)
+		require.NoError(t, err)
+		require.Equal(t, c.expected, actual)
+	}
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Implement the `UnmarshalJSON` on `AutomaticFacetFilter` to handle the case when `automaticFacetFilters` or `automaticOptionalFacetFilters` are just a `string`.
