### PR TITLE
fix: composableFilterOption deserialization fixed

### DIFF
--- a/algolia/internal/opt/facet_filters_test.go
+++ b/algolia/internal/opt/facet_filters_test.go
@@ -125,11 +125,19 @@ func TestFacetFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1","filter2:value2"]`,
-			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+			opt.FacetFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.FacetFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"]]`,
 			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.FacetFilterAnd(opt.FacetFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {
 		var got opt.FacetFiltersOption

--- a/algolia/internal/opt/numeric_filters_test.go
+++ b/algolia/internal/opt/numeric_filters_test.go
@@ -125,11 +125,19 @@ func TestNumericFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1","filter2:value2"]`,
-			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+			opt.NumericFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.NumericFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"]]`,
 			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.NumericFilterAnd(opt.NumericFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {
 		var got opt.NumericFiltersOption

--- a/algolia/internal/opt/optional_filters_test.go
+++ b/algolia/internal/opt/optional_filters_test.go
@@ -125,11 +125,19 @@ func TestOptionalFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1","filter2:value2"]`,
-			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+			opt.OptionalFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.OptionalFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"]]`,
 			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.OptionalFilterAnd(opt.OptionalFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {
 		var got opt.OptionalFiltersOption

--- a/algolia/internal/opt/tag_filters_test.go
+++ b/algolia/internal/opt/tag_filters_test.go
@@ -125,11 +125,19 @@ func TestTagFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1","filter2:value2"]`,
-			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+			opt.TagFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`[" filter1:value1 "," filter2:value2 "]`,
+			opt.TagFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"]]`,
 			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+		},
+		{
+			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.TagFilterAnd(opt.TagFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {
 		var got opt.TagFiltersOption

--- a/algolia/opt/composable_filter_test.go
+++ b/algolia/opt/composable_filter_test.go
@@ -47,13 +47,13 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 		{
 			`["color:green","color:yellow"]`,
 			composableFilterOption{[][]string{
-				{`color:green`, `color:yellow`},
+				{`color:green`}, {`color:yellow`},
 			}},
 		},
 		{
 			`[" color:green "," color:yellow "]`,
 			composableFilterOption{[][]string{
-				{`color:green`, `color:yellow`},
+				{`color:green`}, {`color:yellow`},
 			}},
 		},
 		{
@@ -68,6 +68,20 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 			composableFilterOption{[][]string{
 				{`color:green`},
 				{`color:yellow`},
+			}},
+		},
+		{
+			`[["color:green","color:yellow"], ["color:blue"]]`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+				{`color:blue`},
+			}},
+		},
+		{
+			`[["color:green","color:yellow"], "color:blue"]`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+				{`color:blue`},
 			}},
 		},
 	} {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

`composableFilterOption` deserialization fixed to handle mixed cases. Also, deserialization logic is fixed to take the first level as separate and group. With the changes deserialization handles the following cases;
```
["color:green","color:yellow"] => [["color:green"],["color:yellow"]]

[["color:green","color:yellow"], "color:blue"] => [["color:green","color:yellow"], ["color:blue"]]
```

Other client library PRs that fix related issues are based.  Ex: https://github.com/algolia/algoliasearch-client-java-2/pull/771

**PS:** When fixing this issue, we noticed that legacy one string parsing is also not handled properly in this client. It will be addressed with another PR.
