### PR TITLE
fix: handle composableFilterOption deserialization for legacy usage

### DIFF
--- a/algolia/internal/opt/facet_filters_test.go
+++ b/algolia/internal/opt/facet_filters_test.go
@@ -117,10 +117,14 @@ func TestFacetFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`"filter1:value1,filter2:value2"`,
-			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
+			opt.FacetFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`" filter1:value1 , filter2:value2 "`,
+			opt.FacetFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`"(filter1:value1,filter2:value2)"`,
 			opt.FacetFilterOr("filter1:value1", "filter2:value2"),
 		},
 		{
@@ -137,6 +141,14 @@ func TestFacetFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.FacetFilterAnd(opt.FacetFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`["filter1:value1,filter2:value2","filter3:value3"]`,
+			opt.FacetFilterAnd(opt.FacetFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`"(filter1:value1,filter2:value2),filter3:value3"`,
 			opt.FacetFilterAnd(opt.FacetFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {

--- a/algolia/internal/opt/facet_filters_test.go
+++ b/algolia/internal/opt/facet_filters_test.go
@@ -145,7 +145,7 @@ func TestFacetFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1,filter2:value2","filter3:value3"]`,
-			opt.FacetFilterAnd(opt.FacetFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+			opt.FacetFilterAnd("filter1:value1,filter2:value2", "filter3:value3"),
 		},
 		{
 			`"(filter1:value1,filter2:value2),filter3:value3"`,

--- a/algolia/internal/opt/numeric_filters_test.go
+++ b/algolia/internal/opt/numeric_filters_test.go
@@ -145,7 +145,7 @@ func TestNumericFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1,filter2:value2","filter3:value3"]`,
-			opt.NumericFilterAnd(opt.NumericFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+			opt.NumericFilterAnd("filter1:value1,filter2:value2", "filter3:value3"),
 		},
 		{
 			`"(filter1:value1,filter2:value2),filter3:value3"`,

--- a/algolia/internal/opt/numeric_filters_test.go
+++ b/algolia/internal/opt/numeric_filters_test.go
@@ -117,10 +117,14 @@ func TestNumericFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`"filter1:value1,filter2:value2"`,
-			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
+			opt.NumericFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`" filter1:value1 , filter2:value2 "`,
+			opt.NumericFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`"(filter1:value1,filter2:value2)"`,
 			opt.NumericFilterOr("filter1:value1", "filter2:value2"),
 		},
 		{
@@ -137,6 +141,14 @@ func TestNumericFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.NumericFilterAnd(opt.NumericFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`["filter1:value1,filter2:value2","filter3:value3"]`,
+			opt.NumericFilterAnd(opt.NumericFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`"(filter1:value1,filter2:value2),filter3:value3"`,
 			opt.NumericFilterAnd(opt.NumericFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {

--- a/algolia/internal/opt/optional_filters_test.go
+++ b/algolia/internal/opt/optional_filters_test.go
@@ -145,7 +145,7 @@ func TestOptionalFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1,filter2:value2","filter3:value3"]`,
-			opt.OptionalFilterAnd(opt.OptionalFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+			opt.OptionalFilterAnd("filter1:value1,filter2:value2", "filter3:value3"),
 		},
 		{
 			`"(filter1:value1,filter2:value2),filter3:value3"`,

--- a/algolia/internal/opt/optional_filters_test.go
+++ b/algolia/internal/opt/optional_filters_test.go
@@ -117,10 +117,14 @@ func TestOptionalFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`"filter1:value1,filter2:value2"`,
-			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
+			opt.OptionalFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`" filter1:value1 , filter2:value2 "`,
+			opt.OptionalFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`"(filter1:value1,filter2:value2)"`,
 			opt.OptionalFilterOr("filter1:value1", "filter2:value2"),
 		},
 		{
@@ -137,6 +141,14 @@ func TestOptionalFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.OptionalFilterAnd(opt.OptionalFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`["filter1:value1,filter2:value2","filter3:value3"]`,
+			opt.OptionalFilterAnd(opt.OptionalFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`"(filter1:value1,filter2:value2),filter3:value3"`,
 			opt.OptionalFilterAnd(opt.OptionalFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {

--- a/algolia/internal/opt/tag_filters_test.go
+++ b/algolia/internal/opt/tag_filters_test.go
@@ -145,7 +145,7 @@ func TestTagFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`["filter1:value1,filter2:value2","filter3:value3"]`,
-			opt.TagFilterAnd(opt.TagFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+			opt.TagFilterAnd("filter1:value1,filter2:value2", "filter3:value3"),
 		},
 		{
 			`"(filter1:value1,filter2:value2),filter3:value3"`,

--- a/algolia/internal/opt/tag_filters_test.go
+++ b/algolia/internal/opt/tag_filters_test.go
@@ -117,15 +117,19 @@ func TestTagFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`"filter1:value1,filter2:value2"`,
-			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+			opt.TagFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`" filter1:value1 , filter2:value2 "`,
-			opt.TagFilterOr("filter1:value1", "filter2:value2"),
+			opt.TagFilterAnd("filter1:value1", "filter2:value2"),
 		},
 		{
 			`["filter1:value1","filter2:value2"]`,
 			opt.TagFilterAnd("filter1:value1", "filter2:value2"),
+		},
+		{
+			`"(filter1:value1,filter2:value2)"`,
+			opt.TagFilterOr("filter1:value1", "filter2:value2"),
 		},
 		{
 			`[" filter1:value1 "," filter2:value2 "]`,
@@ -137,6 +141,14 @@ func TestTagFilters_LegacyDeserialization(t *testing.T) {
 		},
 		{
 			`[["filter1:value1","filter2:value2"], "filter3:value3"]`,
+			opt.TagFilterAnd(opt.TagFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`["filter1:value1,filter2:value2","filter3:value3"]`,
+			opt.TagFilterAnd(opt.TagFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
+		},
+		{
+			`"(filter1:value1,filter2:value2),filter3:value3"`,
 			opt.TagFilterAnd(opt.TagFilterOr("filter1:value1", "filter2:value2"), "filter3:value3"),
 		},
 	} {

--- a/algolia/opt/composable_filter.go
+++ b/algolia/opt/composable_filter.go
@@ -139,7 +139,7 @@ func (o *composableFilterOption) UnmarshalJSON(data []byte) error {
 		for _, filter := range ors {
 			filter = strings.Trim(filter, " ")
 			if len(filter) > 0 {
-				cleanORs = append(cleanORs, strings.Split(filter, ",")...)
+				cleanORs = append(cleanORs, filter)
 			}
 		}
 		if len(cleanORs) > 0 {

--- a/algolia/opt/composable_filter.go
+++ b/algolia/opt/composable_filter.go
@@ -82,6 +82,11 @@ func (o *composableFilterOption) UnmarshalJSON(data []byte) error {
 		options []interface{}
 	)
 
+	// Handles legacy one-string format as filters.
+	// Adds outer groups as `ands`, adds inner groups as `ors` if there are any.
+	//"A:1,B:2"       => [["A:1"],["B:2"]]
+	//"(A:1,B:2),C:3" => [["A:1","B:2"],["C:3"]]
+	//"(A:1,B:2)"     => [["A:1","B:2"]]
 	if json.Unmarshal(data, &filter) == nil {
 		ok = true
 		replacer := strings.NewReplacer("(", " ", ")", " ")

--- a/algolia/opt/composable_filter_test.go
+++ b/algolia/opt/composable_filter_test.go
@@ -87,7 +87,7 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 		{
 			`["color:green,color:yellow","color:blue"]`,
 			composableFilterOption{[][]string{
-				{`color:green`, `color:yellow`},
+				{`color:green,color:yellow`},
 				{`color:blue`},
 			}},
 		},

--- a/algolia/opt/composable_filter_test.go
+++ b/algolia/opt/composable_filter_test.go
@@ -35,13 +35,13 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 		{
 			`"color:green,color:yellow"`,
 			composableFilterOption{[][]string{
-				{`color:green`, `color:yellow`},
+				{`color:green`}, {`color:yellow`},
 			}},
 		},
 		{
 			`" color:green , color:yellow "`,
 			composableFilterOption{[][]string{
-				{`color:green`, `color:yellow`},
+				{`color:green`}, {`color:yellow`},
 			}},
 		},
 		{
@@ -79,6 +79,20 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 		},
 		{
 			`[["color:green","color:yellow"], "color:blue"]`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+				{`color:blue`},
+			}},
+		},
+		{
+			`["color:green,color:yellow","color:blue"]`,
+			composableFilterOption{[][]string{
+				{`color:green`, `color:yellow`},
+				{`color:blue`},
+			}},
+		},
+		{
+			`"(color:green,color:yellow),color:black"`,
 			composableFilterOption{[][]string{
 				{`color:green`, `color:yellow`},
 				{`color:blue`},

--- a/algolia/opt/composable_filter_test.go
+++ b/algolia/opt/composable_filter_test.go
@@ -92,7 +92,7 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 			}},
 		},
 		{
-			`"(color:green,color:yellow),color:black"`,
+			`"(color:green,color:yellow),color:blue"`,
 			composableFilterOption{[][]string{
 				{`color:green`, `color:yellow`},
 				{`color:blue`},
@@ -108,8 +108,8 @@ func TestComposableFilterOption_UnmarshalJSON(t *testing.T) {
 
 		require.Equal(
 			t,
-			len(fGot),
-			len(fExpected),
+			fGot,
+			fExpected,
 			"expected %v as deserialized filters instead of %v for payload %q",
 			fExpected,
 			fGot,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

One-string legacy filter deserialization behavior is fixed to handle parenthesis usage with multiple groups.
Added more tests to cover possible usages.

**PS:** This behavior is already fixed in other client libraries. This implementation is based on those PRs which are fixing the same issue.

https://github.com/algolia/algoliasearch-client-java-2/pull/771
https://github.com/algolia/algoliasearch-client-csharp/pull/803

## What problem is this fixing?

When legacy one-string filters are used deserialization was not working as expected. 
Normally, it should work as below;
```
"color:green,color:yellow" => [["color:green"],["color:yellow"]]

"(color:green,color:yellow),color:blue" => [["color:green","color:yellow"], ["color:blue"]]

"(color:green,color:yellow)" => [["color:green","color:yellow"]]
```
