### PR TITLE
fix: set default value to string slices to prevent `null` unmarshalling

### DIFF
--- a/algolia/internal/gen/templates/option/string_slice.go.tmpl
+++ b/algolia/internal/gen/templates/option/string_slice.go.tmpl
@@ -16,6 +16,9 @@ type {{ .Name }}Option struct {
 
 // {{ .Name }} wraps the given value into a {{ .Name }}Option.
 func {{ .Name }}(v ...string) *{{ .Name }}Option {
+    if v == nil {
+        return &{{ .Name }}Option{[]string{}}
+    }
     return &{{ .Name }}Option{v}
 }
 

--- a/algolia/opt/advanced_syntax_features.go
+++ b/algolia/opt/advanced_syntax_features.go
@@ -16,6 +16,9 @@ type AdvancedSyntaxFeaturesOption struct {
 
 // AdvancedSyntaxFeatures wraps the given value into a AdvancedSyntaxFeaturesOption.
 func AdvancedSyntaxFeatures(v ...string) *AdvancedSyntaxFeaturesOption {
+	if v == nil {
+		return &AdvancedSyntaxFeaturesOption{[]string{}}
+	}
 	return &AdvancedSyntaxFeaturesOption{v}
 }
 

--- a/algolia/opt/alternatives_as_exact.go
+++ b/algolia/opt/alternatives_as_exact.go
@@ -16,6 +16,9 @@ type AlternativesAsExactOption struct {
 
 // AlternativesAsExact wraps the given value into a AlternativesAsExactOption.
 func AlternativesAsExact(v ...string) *AlternativesAsExactOption {
+	if v == nil {
+		return &AlternativesAsExactOption{[]string{}}
+	}
 	return &AlternativesAsExactOption{v}
 }
 

--- a/algolia/opt/analytics_tags.go
+++ b/algolia/opt/analytics_tags.go
@@ -16,6 +16,9 @@ type AnalyticsTagsOption struct {
 
 // AnalyticsTags wraps the given value into a AnalyticsTagsOption.
 func AnalyticsTags(v ...string) *AnalyticsTagsOption {
+	if v == nil {
+		return &AnalyticsTagsOption{[]string{}}
+	}
 	return &AnalyticsTagsOption{v}
 }
 

--- a/algolia/opt/attributes_for_faceting.go
+++ b/algolia/opt/attributes_for_faceting.go
@@ -16,6 +16,9 @@ type AttributesForFacetingOption struct {
 
 // AttributesForFaceting wraps the given value into a AttributesForFacetingOption.
 func AttributesForFaceting(v ...string) *AttributesForFacetingOption {
+	if v == nil {
+		return &AttributesForFacetingOption{[]string{}}
+	}
 	return &AttributesForFacetingOption{v}
 }
 

--- a/algolia/opt/attributes_to_highlight.go
+++ b/algolia/opt/attributes_to_highlight.go
@@ -16,6 +16,9 @@ type AttributesToHighlightOption struct {
 
 // AttributesToHighlight wraps the given value into a AttributesToHighlightOption.
 func AttributesToHighlight(v ...string) *AttributesToHighlightOption {
+	if v == nil {
+		return &AttributesToHighlightOption{[]string{}}
+	}
 	return &AttributesToHighlightOption{v}
 }
 

--- a/algolia/opt/attributes_to_retrieve.go
+++ b/algolia/opt/attributes_to_retrieve.go
@@ -16,6 +16,9 @@ type AttributesToRetrieveOption struct {
 
 // AttributesToRetrieve wraps the given value into a AttributesToRetrieveOption.
 func AttributesToRetrieve(v ...string) *AttributesToRetrieveOption {
+	if v == nil {
+		return &AttributesToRetrieveOption{[]string{}}
+	}
 	return &AttributesToRetrieveOption{v}
 }
 

--- a/algolia/opt/attributes_to_snippet.go
+++ b/algolia/opt/attributes_to_snippet.go
@@ -16,6 +16,9 @@ type AttributesToSnippetOption struct {
 
 // AttributesToSnippet wraps the given value into a AttributesToSnippetOption.
 func AttributesToSnippet(v ...string) *AttributesToSnippetOption {
+	if v == nil {
+		return &AttributesToSnippetOption{[]string{}}
+	}
 	return &AttributesToSnippetOption{v}
 }
 

--- a/algolia/opt/attributes_to_transliterate.go
+++ b/algolia/opt/attributes_to_transliterate.go
@@ -16,6 +16,9 @@ type AttributesToTransliterateOption struct {
 
 // AttributesToTransliterate wraps the given value into a AttributesToTransliterateOption.
 func AttributesToTransliterate(v ...string) *AttributesToTransliterateOption {
+	if v == nil {
+		return &AttributesToTransliterateOption{[]string{}}
+	}
 	return &AttributesToTransliterateOption{v}
 }
 

--- a/algolia/opt/camel_case_attributes.go
+++ b/algolia/opt/camel_case_attributes.go
@@ -16,6 +16,9 @@ type CamelCaseAttributesOption struct {
 
 // CamelCaseAttributes wraps the given value into a CamelCaseAttributesOption.
 func CamelCaseAttributes(v ...string) *CamelCaseAttributesOption {
+	if v == nil {
+		return &CamelCaseAttributesOption{[]string{}}
+	}
 	return &CamelCaseAttributesOption{v}
 }
 

--- a/algolia/opt/custom_ranking.go
+++ b/algolia/opt/custom_ranking.go
@@ -16,6 +16,9 @@ type CustomRankingOption struct {
 
 // CustomRanking wraps the given value into a CustomRankingOption.
 func CustomRanking(v ...string) *CustomRankingOption {
+	if v == nil {
+		return &CustomRankingOption{[]string{}}
+	}
 	return &CustomRankingOption{v}
 }
 

--- a/algolia/opt/disable_exact_on_attributes.go
+++ b/algolia/opt/disable_exact_on_attributes.go
@@ -16,6 +16,9 @@ type DisableExactOnAttributesOption struct {
 
 // DisableExactOnAttributes wraps the given value into a DisableExactOnAttributesOption.
 func DisableExactOnAttributes(v ...string) *DisableExactOnAttributesOption {
+	if v == nil {
+		return &DisableExactOnAttributesOption{[]string{}}
+	}
 	return &DisableExactOnAttributesOption{v}
 }
 

--- a/algolia/opt/disable_prefix_on_attributes.go
+++ b/algolia/opt/disable_prefix_on_attributes.go
@@ -16,6 +16,9 @@ type DisablePrefixOnAttributesOption struct {
 
 // DisablePrefixOnAttributes wraps the given value into a DisablePrefixOnAttributesOption.
 func DisablePrefixOnAttributes(v ...string) *DisablePrefixOnAttributesOption {
+	if v == nil {
+		return &DisablePrefixOnAttributesOption{[]string{}}
+	}
 	return &DisablePrefixOnAttributesOption{v}
 }
 

--- a/algolia/opt/disable_typo_tolerance_on_attributes.go
+++ b/algolia/opt/disable_typo_tolerance_on_attributes.go
@@ -16,6 +16,9 @@ type DisableTypoToleranceOnAttributesOption struct {
 
 // DisableTypoToleranceOnAttributes wraps the given value into a DisableTypoToleranceOnAttributesOption.
 func DisableTypoToleranceOnAttributes(v ...string) *DisableTypoToleranceOnAttributesOption {
+	if v == nil {
+		return &DisableTypoToleranceOnAttributesOption{[]string{}}
+	}
 	return &DisableTypoToleranceOnAttributesOption{v}
 }
 

--- a/algolia/opt/disable_typo_tolerance_on_words.go
+++ b/algolia/opt/disable_typo_tolerance_on_words.go
@@ -16,6 +16,9 @@ type DisableTypoToleranceOnWordsOption struct {
 
 // DisableTypoToleranceOnWords wraps the given value into a DisableTypoToleranceOnWordsOption.
 func DisableTypoToleranceOnWords(v ...string) *DisableTypoToleranceOnWordsOption {
+	if v == nil {
+		return &DisableTypoToleranceOnWordsOption{[]string{}}
+	}
 	return &DisableTypoToleranceOnWordsOption{v}
 }
 

--- a/algolia/opt/explain.go
+++ b/algolia/opt/explain.go
@@ -16,6 +16,9 @@ type ExplainOption struct {
 
 // Explain wraps the given value into a ExplainOption.
 func Explain(v ...string) *ExplainOption {
+	if v == nil {
+		return &ExplainOption{[]string{}}
+	}
 	return &ExplainOption{v}
 }
 

--- a/algolia/opt/facets.go
+++ b/algolia/opt/facets.go
@@ -16,6 +16,9 @@ type FacetsOption struct {
 
 // Facets wraps the given value into a FacetsOption.
 func Facets(v ...string) *FacetsOption {
+	if v == nil {
+		return &FacetsOption{[]string{}}
+	}
 	return &FacetsOption{v}
 }
 

--- a/algolia/opt/index_languages.go
+++ b/algolia/opt/index_languages.go
@@ -16,6 +16,9 @@ type IndexLanguagesOption struct {
 
 // IndexLanguages wraps the given value into a IndexLanguagesOption.
 func IndexLanguages(v ...string) *IndexLanguagesOption {
+	if v == nil {
+		return &IndexLanguagesOption{[]string{}}
+	}
 	return &IndexLanguagesOption{v}
 }
 

--- a/algolia/opt/natural_languages.go
+++ b/algolia/opt/natural_languages.go
@@ -16,6 +16,9 @@ type NaturalLanguagesOption struct {
 
 // NaturalLanguages wraps the given value into a NaturalLanguagesOption.
 func NaturalLanguages(v ...string) *NaturalLanguagesOption {
+	if v == nil {
+		return &NaturalLanguagesOption{[]string{}}
+	}
 	return &NaturalLanguagesOption{v}
 }
 

--- a/algolia/opt/numeric_attributes_for_filtering.go
+++ b/algolia/opt/numeric_attributes_for_filtering.go
@@ -16,6 +16,9 @@ type NumericAttributesForFilteringOption struct {
 
 // NumericAttributesForFiltering wraps the given value into a NumericAttributesForFilteringOption.
 func NumericAttributesForFiltering(v ...string) *NumericAttributesForFilteringOption {
+	if v == nil {
+		return &NumericAttributesForFilteringOption{[]string{}}
+	}
 	return &NumericAttributesForFilteringOption{v}
 }
 

--- a/algolia/opt/optional_words.go
+++ b/algolia/opt/optional_words.go
@@ -16,6 +16,9 @@ type OptionalWordsOption struct {
 
 // OptionalWords wraps the given value into a OptionalWordsOption.
 func OptionalWords(v ...string) *OptionalWordsOption {
+	if v == nil {
+		return &OptionalWordsOption{[]string{}}
+	}
 	return &OptionalWordsOption{v}
 }
 

--- a/algolia/opt/query_languages.go
+++ b/algolia/opt/query_languages.go
@@ -16,6 +16,9 @@ type QueryLanguagesOption struct {
 
 // QueryLanguages wraps the given value into a QueryLanguagesOption.
 func QueryLanguages(v ...string) *QueryLanguagesOption {
+	if v == nil {
+		return &QueryLanguagesOption{[]string{}}
+	}
 	return &QueryLanguagesOption{v}
 }
 

--- a/algolia/opt/ranking.go
+++ b/algolia/opt/ranking.go
@@ -16,6 +16,9 @@ type RankingOption struct {
 
 // Ranking wraps the given value into a RankingOption.
 func Ranking(v ...string) *RankingOption {
+	if v == nil {
+		return &RankingOption{[]string{}}
+	}
 	return &RankingOption{v}
 }
 

--- a/algolia/opt/referers.go
+++ b/algolia/opt/referers.go
@@ -16,6 +16,9 @@ type ReferersOption struct {
 
 // Referers wraps the given value into a ReferersOption.
 func Referers(v ...string) *ReferersOption {
+	if v == nil {
+		return &ReferersOption{[]string{}}
+	}
 	return &ReferersOption{v}
 }
 

--- a/algolia/opt/replicas.go
+++ b/algolia/opt/replicas.go
@@ -16,6 +16,10 @@ type ReplicasOption struct {
 
 // Replicas wraps the given value into a ReplicasOption.
 func Replicas(v ...string) *ReplicasOption {
+	if v == nil {
+		return &ReplicasOption{[]string{}}
+	}
+
 	return &ReplicasOption{v}
 }
 

--- a/algolia/opt/replicas.go
+++ b/algolia/opt/replicas.go
@@ -19,7 +19,6 @@ func Replicas(v ...string) *ReplicasOption {
 	if v == nil {
 		return &ReplicasOption{[]string{}}
 	}
-
 	return &ReplicasOption{v}
 }
 

--- a/algolia/opt/response_fields.go
+++ b/algolia/opt/response_fields.go
@@ -16,6 +16,9 @@ type ResponseFieldsOption struct {
 
 // ResponseFields wraps the given value into a ResponseFieldsOption.
 func ResponseFields(v ...string) *ResponseFieldsOption {
+	if v == nil {
+		return &ResponseFieldsOption{[]string{}}
+	}
 	return &ResponseFieldsOption{v}
 }
 

--- a/algolia/opt/restrict_indices.go
+++ b/algolia/opt/restrict_indices.go
@@ -16,6 +16,9 @@ type RestrictIndicesOption struct {
 
 // RestrictIndices wraps the given value into a RestrictIndicesOption.
 func RestrictIndices(v ...string) *RestrictIndicesOption {
+	if v == nil {
+		return &RestrictIndicesOption{[]string{}}
+	}
 	return &RestrictIndicesOption{v}
 }
 

--- a/algolia/opt/restrict_searchable_attributes.go
+++ b/algolia/opt/restrict_searchable_attributes.go
@@ -16,6 +16,9 @@ type RestrictSearchableAttributesOption struct {
 
 // RestrictSearchableAttributes wraps the given value into a RestrictSearchableAttributesOption.
 func RestrictSearchableAttributes(v ...string) *RestrictSearchableAttributesOption {
+	if v == nil {
+		return &RestrictSearchableAttributesOption{[]string{}}
+	}
 	return &RestrictSearchableAttributesOption{v}
 }
 

--- a/algolia/opt/rule_contexts.go
+++ b/algolia/opt/rule_contexts.go
@@ -16,6 +16,9 @@ type RuleContextsOption struct {
 
 // RuleContexts wraps the given value into a RuleContextsOption.
 func RuleContexts(v ...string) *RuleContextsOption {
+	if v == nil {
+		return &RuleContextsOption{[]string{}}
+	}
 	return &RuleContextsOption{v}
 }
 

--- a/algolia/opt/scopes.go
+++ b/algolia/opt/scopes.go
@@ -16,6 +16,9 @@ type ScopesOption struct {
 
 // Scopes wraps the given value into a ScopesOption.
 func Scopes(v ...string) *ScopesOption {
+	if v == nil {
+		return &ScopesOption{[]string{}}
+	}
 	return &ScopesOption{v}
 }
 

--- a/algolia/opt/searchable_attributes.go
+++ b/algolia/opt/searchable_attributes.go
@@ -16,6 +16,9 @@ type SearchableAttributesOption struct {
 
 // SearchableAttributes wraps the given value into a SearchableAttributesOption.
 func SearchableAttributes(v ...string) *SearchableAttributesOption {
+	if v == nil {
+		return &SearchableAttributesOption{[]string{}}
+	}
 	return &SearchableAttributesOption{v}
 }
 

--- a/algolia/opt/unretrievable_attributes.go
+++ b/algolia/opt/unretrievable_attributes.go
@@ -16,6 +16,9 @@ type UnretrievableAttributesOption struct {
 
 // UnretrievableAttributes wraps the given value into a UnretrievableAttributesOption.
 func UnretrievableAttributes(v ...string) *UnretrievableAttributesOption {
+	if v == nil {
+		return &UnretrievableAttributesOption{[]string{}}
+	}
 	return &UnretrievableAttributesOption{v}
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Added default value to string slice initialization to prevent `null` unmarshalling. 

## What problem is this fixing?

When initializing string slices with empty arguments, the value was set to nil, and when unmarshalling it option value was sent as `null` instead `[]`.

Example;  

```
res, err := index.SetSettings(search.Settings{
		Replicas: opt.Replicas(),
	})
```

sent as 
`{"replicas": null}` instead of `{"replicas": []}`. 

This PR is fixing the this with updating `string_slice.go.tmpl`. 