### PR TITLE
fix: unmarshal the legacy format before trying the new one

### DIFF
--- a/algolia/search/rule_consequence_params.go
+++ b/algolia/search/rule_consequence_params.go
@@ -46,22 +46,22 @@ func (q *RuleQuery) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	var objectQuery RuleQueryObjectQuery
+	if err := json.Unmarshal(data, &objectQuery); err == nil {
+		q.objectQuery = &objectQuery
+	}
+
 	// Kept for backward-compatibility only
 	var incrementalEdit struct {
 		Remove []string `json:"remove"`
 	}
-	if err := json.Unmarshal(data, &incrementalEdit); err == nil && len(incrementalEdit.Remove) > 0 {
-		var edits []QueryEdit
-		for _, word := range incrementalEdit.Remove {
-			edits = append(edits, RemoveEdit(word))
+	if err := json.Unmarshal(data, &incrementalEdit); err == nil {
+		if q.objectQuery == nil {
+			q.objectQuery = &RuleQueryObjectQuery{}
 		}
-		q.objectQuery = &RuleQueryObjectQuery{Edits: edits}
-		return nil
-	}
-
-	var objectQuery RuleQueryObjectQuery
-	if err := json.Unmarshal(data, &objectQuery); err == nil {
-		q.objectQuery = &objectQuery
+		for _, word := range incrementalEdit.Remove {
+			q.objectQuery.Edits = append(q.objectQuery.Edits, RemoveEdit(word))
+		}
 		return nil
 	}
 

--- a/algolia/search/rule_consequence_params.go
+++ b/algolia/search/rule_consequence_params.go
@@ -46,22 +46,22 @@ func (q *RuleQuery) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	var objectQuery RuleQueryObjectQuery
-	if err := json.Unmarshal(data, &objectQuery); err == nil {
-		q.objectQuery = &objectQuery
-		return nil
-	}
-
 	// Kept for backward-compatibility only
 	var incrementalEdit struct {
 		Remove []string `json:"remove"`
 	}
-	if err := json.Unmarshal(data, &incrementalEdit); err == nil {
+	if err := json.Unmarshal(data, &incrementalEdit); err == nil && len(incrementalEdit.Remove) > 0 {
 		var edits []QueryEdit
 		for _, word := range incrementalEdit.Remove {
 			edits = append(edits, RemoveEdit(word))
 		}
 		q.objectQuery = &RuleQueryObjectQuery{Edits: edits}
+		return nil
+	}
+
+	var objectQuery RuleQueryObjectQuery
+	if err := json.Unmarshal(data, &objectQuery); err == nil {
+		q.objectQuery = &objectQuery
 		return nil
 	}
 

--- a/algolia/search/rule_consequence_params_test.go
+++ b/algolia/search/rule_consequence_params_test.go
@@ -40,3 +40,24 @@ func Test_AutomaticFacetFilter_UnmarshalJSON(t *testing.T) {
 		require.Equal(t, c.expected, actual)
 	}
 }
+
+func Test_LegacyParsingOfQueryEdits(t *testing.T) {
+	for _, c := range []struct {
+		input    string
+		expected RuleQuery
+	}{
+		{
+			input:    `{"remove":["myWord"]}`,
+			expected: RuleQuery{objectQuery: &RuleQueryObjectQuery{Edits: []QueryEdit{RemoveEdit("myWord")}}},
+		},
+		{
+			input:    `{"edits":[{"type":"remove","delete":"myWord"}]}`,
+			expected: RuleQuery{objectQuery: &RuleQueryObjectQuery{Edits: []QueryEdit{RemoveEdit("myWord")}}},
+		},
+	} {
+		var actual RuleQuery
+		err := json.Unmarshal([]byte(c.input), &actual)
+		require.NoError(t, err)
+		require.Equal(t, c.expected, actual)
+	}
+}

--- a/algolia/search/rule_consequence_params_test.go
+++ b/algolia/search/rule_consequence_params_test.go
@@ -54,6 +54,10 @@ func Test_LegacyParsingOfQueryEdits(t *testing.T) {
 			input:    `{"edits":[{"type":"remove","delete":"myWord"}]}`,
 			expected: RuleQuery{objectQuery: &RuleQueryObjectQuery{Edits: []QueryEdit{RemoveEdit("myWord")}}},
 		},
+		{
+			input:    `{"edits":[{"type":"remove","delete":"myWord1"}],"remove":["myWord2"]}`,
+			expected: RuleQuery{objectQuery: &RuleQueryObjectQuery{Edits: []QueryEdit{RemoveEdit("myWord1"), RemoveEdit("myWord2")}}},
+		},
 	} {
 		var actual RuleQuery
 		err := json.Unmarshal([]byte(c.input), &actual)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Try first the legacy format parsing before new format and continue only if no edits are retrieved

## What problem is this fixing?

Fix the unmarshalling of rules consequence using the legacy format to edit the query words. The permissive parsing of the new format was taking precedence leading to rules without edits.
