### PR TITLE
chore: run ci with go 1.18, 1.19 and 1.20 but deprecate 1.13, 1.14 and 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,11 +101,11 @@ workflows:
           matrix:
               parameters:
                 go_version:
-                    - "1.13"
-                    - "1.14"
-                    - "1.15"
                     - "1.16"
                     - "1.17"
+                    - "1.18"
+                    - "1.19"
+                    - "1.20"
 
       - integration-tests:
           filters:
@@ -116,8 +116,8 @@ workflows:
           matrix:
               parameters:
                 go_version:
-                    - "1.13"
-                    - "1.14"
-                    - "1.15"
                     - "1.16"
                     - "1.17"
+                    - "1.18"
+                    - "1.19"
+                    - "1.20"


### PR DESCRIPTION
## Describe your change

Run ci with go 1.18, 1.19 and 1.20 but deprecate 1.13, 1.14 and 1.15.

Golang only supports the 2 latest versions so 1.18 is already unmaintained that's why I deprecated the oldest ones to keep the same amount of versions tested
