### PR TITLE
fix: pass unpacked options in some requests call

### DIFF
--- a/algolia/personalization/client_personalization.go
+++ b/algolia/personalization/client_personalization.go
@@ -9,13 +9,13 @@ import (
 
 func (c *Client) GetPersonalizationStrategy(opts ...interface{}) (strategy Strategy, err error) {
 	path := c.pathPersonalization("")
-	err = c.transport.Request(&strategy, http.MethodGet, path, nil, call.Read)
+	err = c.transport.Request(&strategy, http.MethodGet, path, nil, call.Read, opts...)
 	return
 }
 
 func (c *Client) SetPersonalizationStrategy(strategy Strategy, opts ...interface{}) (res SetPersonalizationStrategyRes, err error) {
 	path := c.pathPersonalization("")
-	err = c.transport.Request(&strategy, http.MethodPost, path, strategy, call.Write)
+	err = c.transport.Request(&strategy, http.MethodPost, path, strategy, call.Write, opts...)
 	return
 }
 

--- a/algolia/recommend/client_recommend.go
+++ b/algolia/recommend/client_recommend.go
@@ -9,7 +9,7 @@ import (
 
 func (c *Client) GetRecommendations(options []RecommendationsOptions, opts ...interface{}) (res search.MultipleQueriesRes, err error) {
 	path := c.path("")
-	err = c.transport.Request(&res, http.MethodPost, path, multipleOptions{options}, call.Read)
+	err = c.transport.Request(&res, http.MethodPost, path, multipleOptions{options}, call.Read, opts...)
 	return
 }
 
@@ -18,7 +18,7 @@ func (c *Client) GetRelatedProducts(options []RelatedProductsOptions, opts ...in
 	for _, o := range options {
 		requests = append(requests, o.recommendationsOptions)
 	}
-	return c.GetRecommendations(requests, opts)
+	return c.GetRecommendations(requests, opts...)
 }
 
 func (c *Client) GetFrequentlyBoughtTogether(options []FrequentlyBoughtTogetherOptions, opts ...interface{}) (res search.MultipleQueriesRes, err error) {
@@ -26,7 +26,7 @@ func (c *Client) GetFrequentlyBoughtTogether(options []FrequentlyBoughtTogetherO
 	for _, o := range options {
 		requests = append(requests, o.recommendationsOptions)
 	}
-	return c.GetRecommendations(requests, opts)
+	return c.GetRecommendations(requests, opts...)
 }
 
 func (c *Client) path(format string, a ...interface{}) string {

--- a/algolia/recommendation/client_personalization.go
+++ b/algolia/recommendation/client_personalization.go
@@ -9,13 +9,13 @@ import (
 
 func (c *Client) GetPersonalizationStrategy(opts ...interface{}) (strategy Strategy, err error) {
 	path := c.pathPersonalization("")
-	err = c.transport.Request(&strategy, http.MethodGet, path, nil, call.Read)
+	err = c.transport.Request(&strategy, http.MethodGet, path, nil, call.Read, opts...)
 	return
 }
 
 func (c *Client) SetPersonalizationStrategy(strategy Strategy, opts ...interface{}) (res SetPersonalizationStrategyRes, err error) {
 	path := c.pathPersonalization("")
-	err = c.transport.Request(&strategy, http.MethodPost, path, strategy, call.Write)
+	err = c.transport.Request(&strategy, http.MethodPost, path, strategy, call.Write, opts...)
 	return
 }
 

--- a/algolia/search/account.go
+++ b/algolia/search/account.go
@@ -141,7 +141,7 @@ func (a *Account) CopyIndex(src, dst *Index, opts ...interface{}) (*wait.Group, 
 		}
 
 		// Send the last batch
-		res, err := dst.SaveObjects(objects, opts)
+		res, err := dst.SaveObjects(objects, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("error while saving batch of objects: %v", err)
 		}

--- a/algolia/search/client.go
+++ b/algolia/search/client.go
@@ -145,5 +145,5 @@ func (c *Client) WaitTask(taskID int64, opts ...interface{}) error {
 			return true, err
 		}
 		return res.Status == "published", nil
-	}, iopt.ExtractWaitConfiguration(opts))
+	}, iopt.ExtractWaitConfiguration(opts...))
 }

--- a/algolia/search/client_dictionaries.go
+++ b/algolia/search/client_dictionaries.go
@@ -35,7 +35,7 @@ func (c *Client) DeleteDictionaryEntries(dictionaryName DictionaryName, objectID
 
 // ClearDictionaryEntries deletes all the dictionary entries from the given dictionary
 func (c *Client) ClearDictionaryEntries(dictionaryName DictionaryName, opts ...interface{}) (res UpdateTaskRes, err error) {
-	return c.ReplaceDictionaryEntries(dictionaryName, []DictionaryEntry{}, opts)
+	return c.ReplaceDictionaryEntries(dictionaryName, []DictionaryEntry{}, opts...)
 }
 
 // SearchDictionaryEntries searches for dictionary entries according to the given query string and any rule

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -46,7 +46,7 @@ func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 			return true, err
 		}
 		return res.Status == "published", nil
-	}, iopt.ExtractWaitConfiguration(opts))
+	}, iopt.ExtractWaitConfiguration(opts...))
 }
 
 func (i *Index) operation(destination, op string, opts ...interface{}) (res UpdateTaskRes, err error) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Fix various miss or unpacked options parameter in `transport.Request` calls

## What problem is this fixing?

Some options were silently ignored due to it
