### PR TITLE
feat(recommend): implement Recommend-level waitTask

### DIFF
--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -101,3 +101,19 @@ func hasObjectID(object interface{}) bool {
 	_, ok := getObjectID(object)
 	return ok
 }
+
+func getScopeFromTaskID(taskID int64) (string, error) {
+	scopeID := (taskID / 10) % 100
+	switch scopeID {
+	case 0:
+		return "index", nil
+	case 1:
+		return "app", nil
+	case 2:
+		return "metis", nil
+	case 3:
+		return "recommend", nil
+	default:
+		return "", fmt.Errorf("invalid taskID scope")
+	}
+}

--- a/algolia/search/utils_test.go
+++ b/algolia/search/utils_test.go
@@ -53,3 +53,19 @@ func TestHasObjectIDField(t *testing.T) {
 
 	require.False(t, hasObjectID(nil))
 }
+
+func TestGetScopeFromTaskID(t *testing.T) {
+	for _, c := range []struct {
+		taskID        int64
+		expectedScope string
+	}{
+		{4001, "index"},
+		{4011, "app"},
+		{4021, "metis"},
+		{4031, "recommend"},
+	} {
+		scope, err := getScopeFromTaskID(c.taskID)
+		require.NoError(t, err)
+		require.Equal(t, c.expectedScope, scope)
+	}
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

Support waiting tasks with a Recommend-level scope. It is slightly different than the index-level task because it expects a model name in the URL. Note that this is historical though, the model name is now useless and both index-level and recommend-level actually work similarly behind the hood.

## What problem is this fixing?

Add the abillity to build recommend rules in Metis.