### PR TITLE
fix(recommend): Handle taskIDs below 1000 as index scope

### DIFF
--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -103,6 +103,9 @@ func hasObjectID(object interface{}) bool {
 }
 
 func getScopeFromTaskID(taskID int64) (string, error) {
+	if taskID < 1000 {
+		return "index", nil
+	}
 	scopeID := (taskID / 10) % 100
 	switch scopeID {
 	case 0:
@@ -114,6 +117,6 @@ func getScopeFromTaskID(taskID int64) (string, error) {
 	case 3:
 		return "recommend", nil
 	default:
-		return "", fmt.Errorf("invalid taskID scope")
+		return "", fmt.Errorf("invalid taskID scope: %d", scopeID)
 	}
 }

--- a/algolia/search/utils_test.go
+++ b/algolia/search/utils_test.go
@@ -58,14 +58,17 @@ func TestGetScopeFromTaskID(t *testing.T) {
 	for _, c := range []struct {
 		taskID        int64
 		expectedScope string
+		expectedError error
 	}{
-		{4001, "index"},
-		{4011, "app"},
-		{4021, "metis"},
-		{4031, "recommend"},
+		{123, "index", nil},
+		{4001, "index", nil},
+		{4011, "app", nil},
+		{4021, "metis", nil},
+		{4031, "recommend", nil},
+		{4041, "", fmt.Errorf("invalid taskID scope: 4")},
 	} {
 		scope, err := getScopeFromTaskID(c.taskID)
-		require.NoError(t, err)
 		require.Equal(t, c.expectedScope, scope)
+		require.Equal(t, c.expectedError, err)
 	}
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Treat taskIDs below 1000 as being of "index" scope.

## What problem is this fixing?

An error was thrown when taskIDs were below 1000 instead of accepting it as being of "index" scope.