### PR TITLE
fix(recommend): Don't return error when unknown scope for taskID

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,5 @@
 # ChangeLog
 
-## [3.29.3](https://github.com/algolia/algoliasearch-client-go/compare/v3.29.2...v3.29.3) (2023-05-15)
-
-## Fix
-
-- fix(recommend): Don't return error when unknown scope for taskID (#735) ([c1be0f7](https://github.com/algolia/algoliasearch-client-go/commit/c1be0f7))
-
 ## [3.29.2](https://github.com/algolia/algoliasearch-client-go/compare/v3.29.1...v3.29.2) (2023-05-11)
 
 ## Fix

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## [3.29.3](https://github.com/algolia/algoliasearch-client-go/compare/v3.29.2...v3.29.3) (2023-05-15)
+
+## Fix
+
+- fix(recommend): Don't return error when unknown scope for taskID (#735) ([c1be0f7](https://github.com/algolia/algoliasearch-client-go/commit/c1be0f7))
+
 ## [3.29.2](https://github.com/algolia/algoliasearch-client-go/compare/v3.29.1...v3.29.2) (2023-05-11)
 
 ## Fix

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -43,7 +43,7 @@ func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 	return waitWithRetry(func() (bool, error) {
 		var res TaskStatusRes
 		var err error
-		scope := getScopeFromTaskID(taskID)
+		scope, _ := getScopeFromTaskID(taskID)
 		if scope == "recommend" {
 			res, err = i.GetRecommendStatus(taskID, opts...)
 		} else {

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -42,10 +42,8 @@ func (i *Index) path(format string, a ...interface{}) string {
 func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 	return waitWithRetry(func() (bool, error) {
 		var res TaskStatusRes
-		scope, err := getScopeFromTaskID(taskID)
-		if err != nil {
-			return true, err
-		}
+		var err error
+		scope := getScopeFromTaskID(taskID)
 		if scope == "recommend" {
 			res, err = i.GetRecommendStatus(taskID, opts...)
 		} else {

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -102,21 +102,21 @@ func hasObjectID(object interface{}) bool {
 	return ok
 }
 
-func getScopeFromTaskID(taskID int64) string {
+func getScopeFromTaskID(taskID int64) (string, error) {
 	if taskID < 1000 {
-		return "index"
+		return "index", nil
 	}
 	scopeID := (taskID / 10) % 100
 	switch scopeID {
 	case 0:
-		return "index"
+		return "index", nil
 	case 1:
-		return "app"
+		return "app", nil
 	case 2:
-		return "metis"
+		return "metis", nil
 	case 3:
-		return "recommend"
+		return "recommend", nil
 	default:
-		return ""
+		return "", fmt.Errorf("taskID '%d' has an invalid scope: %d", taskID, scopeID)
 	}
 }

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -102,21 +102,21 @@ func hasObjectID(object interface{}) bool {
 	return ok
 }
 
-func getScopeFromTaskID(taskID int64) (string, error) {
+func getScopeFromTaskID(taskID int64) string {
 	if taskID < 1000 {
-		return "index", nil
+		return "index"
 	}
 	scopeID := (taskID / 10) % 100
 	switch scopeID {
 	case 0:
-		return "index", nil
+		return "index"
 	case 1:
-		return "app", nil
+		return "app"
 	case 2:
-		return "metis", nil
+		return "metis"
 	case 3:
-		return "recommend", nil
+		return "recommend"
 	default:
-		return "", fmt.Errorf("invalid taskID scope: %d", scopeID)
+		return ""
 	}
 }

--- a/algolia/search/utils_test.go
+++ b/algolia/search/utils_test.go
@@ -58,17 +58,15 @@ func TestGetScopeFromTaskID(t *testing.T) {
 	for _, c := range []struct {
 		taskID        int64
 		expectedScope string
-		expectedError error
 	}{
-		{123, "index", nil},
-		{4001, "index", nil},
-		{4011, "app", nil},
-		{4021, "metis", nil},
-		{4031, "recommend", nil},
-		{4041, "", fmt.Errorf("invalid taskID scope: 4")},
+		{123, "index"},
+		{4001, "index"},
+		{4011, "app"},
+		{4021, "metis"},
+		{4031, "recommend"},
+		{4041, ""},
 	} {
-		scope, err := getScopeFromTaskID(c.taskID)
+		scope := getScopeFromTaskID(c.taskID)
 		require.Equal(t, c.expectedScope, scope)
-		require.Equal(t, c.expectedError, err)
 	}
 }

--- a/algolia/search/utils_test.go
+++ b/algolia/search/utils_test.go
@@ -58,15 +58,17 @@ func TestGetScopeFromTaskID(t *testing.T) {
 	for _, c := range []struct {
 		taskID        int64
 		expectedScope string
+		expectedError error
 	}{
-		{123, "index"},
-		{4001, "index"},
-		{4011, "app"},
-		{4021, "metis"},
-		{4031, "recommend"},
-		{4041, ""},
+		{123, "index", nil},
+		{4001, "index", nil},
+		{4011, "app", nil},
+		{4021, "metis", nil},
+		{4031, "recommend", nil},
+		{4041, "", fmt.Errorf("taskID '4041' has an invalid scope: 4")},
 	} {
-		scope := getScopeFromTaskID(c.taskID)
+		scope, err := getScopeFromTaskID(c.taskID)
 		require.Equal(t, c.expectedScope, scope)
+		require.Equal(t, c.expectedError, err)
 	}
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Don't return an error when an unknown scope has been detected for a given taskID. Instead, simply return an empty string scope.

## What problem is this fixing?

In some cases we might be confronted to taskIDs with unknown scopes, and thus we should not fail and return an error.
