### PR TITLE
fix(recommend): implement dedicated waitRecommendTask function

### DIFF
--- a/algolia/search/client_interface.go
+++ b/algolia/search/client_interface.go
@@ -9,7 +9,9 @@ import (
 type ClientInterface interface {
 	// Misc
 	WaitTask(taskID int64, opts ...interface{}) error
+	WaitRecommendTask(taskID int64, opts ...interface{}) error
 	GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error)
+	GetRecommendStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error)
 	InitIndex(indexName string) *Index
 	ListIndices(opts ...interface{}) (res ListIndicesRes, err error)
 	GetLogs(opts ...interface{}) (res GetLogsRes, err error)

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -41,12 +41,11 @@ func (i *Index) path(format string, a ...interface{}) string {
 // Algolia engine.
 func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 	return waitWithRetry(func() (bool, error) {
-		var res TaskStatusRes
 		res, err := i.GetStatus(taskID, opts...)
 		if err != nil {
 			return true, err
 		}
-		return res.Status == "published", nil
+		return res.Status == taskPublished, nil
 	}, iopt.ExtractWaitConfiguration(opts...))
 }
 
@@ -54,12 +53,11 @@ func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 // taskID is completed on Algolia engine.
 func (i *Index) WaitRecommendTask(taskID int64, opts ...interface{}) error {
 	return waitWithRetry(func() (bool, error) {
-		var res TaskStatusRes
 		res, err := i.GetRecommendStatus(taskID, opts...)
 		if err != nil {
 			return true, err
 		}
-		return res.Status == "published", nil
+		return res.Status == taskPublished, nil
 	}, iopt.ExtractWaitConfiguration(opts...))
 }
 

--- a/algolia/search/index.go
+++ b/algolia/search/index.go
@@ -42,15 +42,20 @@ func (i *Index) path(format string, a ...interface{}) string {
 func (i *Index) WaitTask(taskID int64, opts ...interface{}) error {
 	return waitWithRetry(func() (bool, error) {
 		var res TaskStatusRes
-		scope, err := getScopeFromTaskID(taskID)
+		res, err := i.GetStatus(taskID, opts...)
 		if err != nil {
 			return true, err
 		}
-		if scope == "recommend" {
-			res, err = i.GetRecommendStatus(taskID, opts...)
-		} else {
-			res, err = i.GetStatus(taskID, opts...)
-		}
+		return res.Status == "published", nil
+	}, iopt.ExtractWaitConfiguration(opts...))
+}
+
+// WaitRecommendTask blocks until the task identified by the given Recommend-scope
+// taskID is completed on Algolia engine.
+func (i *Index) WaitRecommendTask(taskID int64, opts ...interface{}) error {
+	return waitWithRetry(func() (bool, error) {
+		var res TaskStatusRes
+		res, err := i.GetRecommendStatus(taskID, opts...)
 		if err != nil {
 			return true, err
 		}

--- a/algolia/search/index_interface.go
+++ b/algolia/search/index_interface.go
@@ -5,7 +5,9 @@ import "github.com/algolia/algoliasearch-client-go/v3/algolia/wait"
 type IndexInterface interface {
 	// Misc
 	WaitTask(taskID int64, opts ...interface{}) error
+	WaitRecommendTask(taskID int64, opts ...interface{}) error
 	GetStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error)
+	GetRecommendStatus(taskID int64, opts ...interface{}) (res TaskStatusRes, err error)
 	GetAppID() string
 	GetName() string
 	ClearObjects(opts ...interface{}) (res UpdateTaskRes, err error)

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -101,22 +101,3 @@ func hasObjectID(object interface{}) bool {
 	_, ok := getObjectID(object)
 	return ok
 }
-
-func getScopeFromTaskID(taskID int64) (string, error) {
-	if taskID < 1000 {
-		return "index", nil
-	}
-	scopeID := (taskID / 10) % 100
-	switch scopeID {
-	case 0:
-		return "index", nil
-	case 1:
-		return "app", nil
-	case 2:
-		return "metis", nil
-	case 3:
-		return "recommend", nil
-	default:
-		return "", fmt.Errorf("invalid taskID scope: %d", scopeID)
-	}
-}

--- a/algolia/search/utils.go
+++ b/algolia/search/utils.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	jsonNull = "null"
+	jsonNull      = "null"
+	taskPublished = "published"
 )
 
 func defaultHosts(appID string) (hosts []*transport.StatefulHost) {

--- a/algolia/search/utils_test.go
+++ b/algolia/search/utils_test.go
@@ -53,22 +53,3 @@ func TestHasObjectIDField(t *testing.T) {
 
 	require.False(t, hasObjectID(nil))
 }
-
-func TestGetScopeFromTaskID(t *testing.T) {
-	for _, c := range []struct {
-		taskID        int64
-		expectedScope string
-		expectedError error
-	}{
-		{123, "index", nil},
-		{4001, "index", nil},
-		{4011, "app", nil},
-		{4021, "metis", nil},
-		{4031, "recommend", nil},
-		{4041, "", fmt.Errorf("invalid taskID scope: 4")},
-	} {
-		scope, err := getScopeFromTaskID(c.taskID)
-		require.Equal(t, c.expectedScope, scope)
-		require.Equal(t, c.expectedError, err)
-	}
-}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change

Add a `WaitRecommendTask` function.

## What problem is this fixing?

Fix `waitTask` implementation for Recommend: use a dedicated function rather than relying on the `taskID` value, which is computed differently in Metis.
