### PR TITLE
feat(renderingContent): parse the redirect attribute

### DIFF
--- a/algolia/search/rendering_content.go
+++ b/algolia/search/rendering_content.go
@@ -3,7 +3,8 @@ package search
 // Content defining how the search interface should be rendered.
 // This is set via the settings for a default value and can be overridden via rules
 type RenderingContent struct {
-	FacetOrdering *FacetOrdering `json:"facetOrdering"`
+	FacetOrdering *FacetOrdering `json:"facetOrdering,omitempty"`
+	Redirect      *Redirect      `json:"redirect,omitempty"`
 }
 
 // Facets and facets values ordering rules container
@@ -13,6 +14,11 @@ type FacetOrdering struct {
 
 	// The ordering of facet values, within an individual list.
 	Values map[string]FacetValuesOrder `json:"values,omitempty"`
+}
+
+// Redirect rule container
+type Redirect struct {
+	Url string `json:"url"`
 }
 
 // Facets ordering rule container

--- a/algolia/search/rendering_content_test.go
+++ b/algolia/search/rendering_content_test.go
@@ -26,6 +26,9 @@ func TestUnmarshalRenderingContent(t *testing.T) {
 					"sortRemainingBy": "alpha"
 				}
 			}
+		},
+		"redirect": {
+			"url": "https://algolia.com/doc"
 		}
 	}`
 	var r RenderingContent
@@ -40,6 +43,8 @@ func TestUnmarshalRenderingContent(t *testing.T) {
 	require.Nil(t, r.FacetOrdering.Values["color"].SortRemainingBy)
 
 	require.Nil(t, r.FacetOrdering.Values["size"].Order)
+
+	require.Equal(t, *r.Redirect, Redirect{Url: "https://algolia.com/doc"})
 }
 
 func TestMarshalRenderingContent(t *testing.T) {
@@ -105,6 +110,26 @@ func TestMarshalRenderingContent(t *testing.T) {
 							"sortRemainingBy": "hidden"
 						}
 					}
+				}
+			}`,
+		},
+		{
+			name: "values with one empty facet value `order`",
+			input: RenderingContent{
+				FacetOrdering: nil,
+			},
+			expected: `{}`,
+		},
+		{
+			name: "values with one empty facet value `order`",
+			input: RenderingContent{
+				Redirect: &Redirect{
+					Url: "https://algolia.com/doc",
+				},
+			},
+			expected: `{
+				"redirect": {
+					"url": "https://algolia.com/doc"
 				}
 			}`,
 		},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Parse the `redirect` attribute and prevent to serialize `FacetOrdering` when nil

## What problem is this fixing?

When unmarshalling a rendering content with only `redirect`, the attribute was ignored. Then marshalling the struct resulted in an invalid renderint content because `FacetOrdering` set to nil is invalid
