### PR TITLE
chore(release.sh): fix release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
+version=$1
+
 function is_version_valid() {
   echo "$1" | grep -q -E '^[0-9]+\.[0-9]+\.[0-9]+$'
   if [[ "$?" == "0" ]]; then return 0; else return 1; fi
 }
 
 function is_working_dir_clean() {
-  if [ -z "$(git status --porcelain)" ]; then return 0; else return 1; fi
+  if [ -z "$(git status --porcelain | grep -v -e ChangeLog.md)" ]; then return 0; else return 1; fi
 }
 
-version=$1
+function is_changelog_modified() {
+  if [ -z "$(git diff ChangeLog.md | grep ${version})" ]; then
+    echo "Missing ChangeLog update" >&2
+    return 1
+  else
+    return 0
+  fi
+}
 
 if ! is_version_valid "$version"; then
   echo "Version '$version' is not valid (expecting X.Y.Z)"
@@ -21,11 +30,12 @@ if ! is_working_dir_clean; then
   echo "Current directory is not clean, release aborted"
   exit 1
 fi
+is_changelog_modified
 
 gsed -i -E "s/version = \".+\"$/version = \"$version\"/" algolia/transport/transport.go
-rake alg:changelog["$version"]
 
-git --no-pager diff
+
+git --no-pager diff ChangeLog.md algolia/transport/transport.go
 printf 'Please confirm those final changes before the automatic release [y/n]: '
 read yes_or_no
 if [[ "$yes_or_no" != "y" ]]; then
@@ -36,5 +46,6 @@ fi
 
 git add ChangeLog.md algolia/transport/transport.go
 git commit -m "chore: Release version $version [skip ci]"
+git push
 git tag "v${version}"
-git push --tags
+git push origin "v${version}"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Fix the release script to be usable:
- Rake is missing to autofill the Changelog
- `git push --tags` was pushing all tags of the repo instead of the one created by the release

For now, the Changelog needs to be set manually, it could be improved in the futur

Tested during the release of v3.30.1: https://github.com/algolia/algoliasearch-client-go/commit/b7c4776fb36744172f4d75c4c5bfddafb412dccf
