### PR TITLE
fix(rules): missing redirect field in RuleConsequence

### DIFF
--- a/algolia/search/rule.go
+++ b/algolia/search/rule.go
@@ -20,6 +20,7 @@ type Rule struct {
 	ObjectID    string             `json:"objectID,omitempty"`
 	Validity    []TimeRange        `json:"validity,omitempty"`
 	Tags        []string           `json:"tags,omitempty"`
+	Scope       string             `json:"scope,omitempty"`
 }
 
 // TimeRange is a pair of begin/end time.Time used to represent a rule validity

--- a/algolia/search/rule_consequence.go
+++ b/algolia/search/rule_consequence.go
@@ -8,6 +8,11 @@ type RuleConsequence struct {
 	FilterPromotes *opt.FilterPromotesOption `json:"filterPromotes,omitempty"`
 	Hide           []HiddenObject            `json:"hide,omitempty"`
 	UserData       interface{}               `json:"userData,omitempty"`
+	Redirect       *RuleRedirect             `json:"redirect,omitempty"`
+}
+
+type RuleRedirect struct {
+	IndexName string `json:"indexName,omitempty"`
 }
 
 type PromotedObject struct {

--- a/algolia/search/rule_test.go
+++ b/algolia/search/rule_test.go
@@ -58,6 +58,17 @@ func TestRule_MarshalJSON(t *testing.T) {
 			},
 			`{"consequence":{},"tags":["visual-editor"]}`,
 		},
+		{
+			Rule{
+				Scope: "redirect",
+				Consequence: RuleConsequence{
+					Redirect: &RuleRedirect{
+						IndexName: "virtual_replica_A",
+					},
+				},
+			},
+			`{"consequence":{"redirect":{"indexName":"virtual_replica_A"}},"scope":"redirect"}`,
+		},
 	} {
 		// Encode the Rule to JSON
 		data, err := json.Marshal(&c.rule)


### PR DESCRIPTION
Previously the SDK would silently drop fields specific to redirect-based rules.  This change adds the missing fields so that it is possible to fetch and re-submit rules without losing the redirect information.

Ideally the SDK would support this natively for all types, but that is a bigger job!