### PR TITLE
fix(circleci): integration-tests must not run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,8 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.17
           go_version: "1.17"
-          requires: integration-tests-1.16
+          requires:
+          - integration-tests-1.16
 
       - integration-tests:
           filters:
@@ -137,7 +138,8 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.18
           go_version: "1.18"
-          requires: integration-tests-1.17
+          requires:
+          - integration-tests-1.17
 
       - integration-tests:
           filters:
@@ -147,7 +149,8 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.19
           go_version: "1.19"
-          requires: integration-tests-1.18
+          requires:
+          - integration-tests-1.18
 
       - integration-tests:
           filters:
@@ -157,7 +160,8 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.20
           go_version: "1.20"
-          requires: integration-tests-1.19
+          requires:
+          - integration-tests-1.19
 
       - integration-tests:
           filters:
@@ -167,4 +171,5 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.21
           go_version: "1.21"
-          requires: integration-tests-1.20
+          requires:
+          - integration-tests-1.20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.17
           go_version: "1.17"
+          requires: integration-tests-1.16
 
       - integration-tests:
           filters:
@@ -136,6 +137,7 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.18
           go_version: "1.18"
+          requires: integration-tests-1.17
 
       - integration-tests:
           filters:
@@ -145,6 +147,7 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.19
           go_version: "1.19"
+          requires: integration-tests-1.18
 
       - integration-tests:
           filters:
@@ -154,6 +157,7 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.20
           go_version: "1.20"
+          requires: integration-tests-1.19
 
       - integration-tests:
           filters:
@@ -163,3 +167,4 @@ workflows:
               ignore: /pull\/[0-9]+/
           name: integration-tests-1.21
           go_version: "1.21"
+          requires: integration-tests-1.20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,18 @@ workflows:
                     - "1.18"
                     - "1.19"
                     - "1.20"
+                    - "1.21"
+
+      # These cannot be run in a matrix because they use the same
+      # resources.
+      - integration-tests:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+              ignore: /pull\/[0-9]+/
+          name: integration-tests-1.16
+          go_version: "1.16"
 
       - integration-tests:
           filters:
@@ -113,11 +125,41 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
               ignore: /pull\/[0-9]+/
-          matrix:
-              parameters:
-                go_version:
-                    - "1.16"
-                    - "1.17"
-                    - "1.18"
-                    - "1.19"
-                    - "1.20"
+          name: integration-tests-1.17
+          go_version: "1.17"
+
+      - integration-tests:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+              ignore: /pull\/[0-9]+/
+          name: integration-tests-1.18
+          go_version: "1.18"
+
+      - integration-tests:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+              ignore: /pull\/[0-9]+/
+          name: integration-tests-1.19
+          go_version: "1.19"
+
+      - integration-tests:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+              ignore: /pull\/[0-9]+/
+          name: integration-tests-1.20
+          go_version: "1.20"
+
+      - integration-tests:
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              # https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
+              ignore: /pull\/[0-9]+/
+          name: integration-tests-1.21
+          go_version: "1.21"

--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -21,7 +21,7 @@ import (
 	iopt "github.com/algolia/algoliasearch-client-go/v3/algolia/internal/opt"
 )
 
-const version = "3.30.1"
+const version = "3.30.2"
 
 type Transport struct {
 	requester     Requester

--- a/cts/analytics/aa_testing_test.go
+++ b/cts/analytics/aa_testing_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAATesting(t *testing.T) {
-	t.Parallel()
 	_, index, indexName := cts.InitSearchClient1AndIndex(t)
 	analyticsClient := cts.InitAnalyticsClient1(t)
 

--- a/cts/analytics/ab_testing_test.go
+++ b/cts/analytics/ab_testing_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestABTesting(t *testing.T) {
-	t.Parallel()
 	searchClient, index1, indexName1 := cts.InitSearchClient1AndIndex(t)
 	indexName2 := indexName1 + "_dev"
 	index2 := searchClient.InitIndex(indexName2)


### PR DESCRIPTION
The integration tests for each Go version are using the same underlying resources and so are triggering races which causes the tests to fail.
