### PR TITLE
fix(transport): clone headers when creating a request

### DIFF
--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -87,7 +87,7 @@ func (t *Transport) Request(
 ) error {
 	var (
 		ctx       = iopt.ExtractContext(opts...)
-		headers   = t.headers
+		headers   = t.headers.Clone()
 		urlParams = make(map[string]string)
 	)
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change
This change clones the http headers when making a new  http request. Previously the same instance of the header map would be used for all requests.
<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

## What problem is this fixing?
This fixes a panic due to concurrent map write that can occur if you have a custom `transport.Requester` that adds additional headers to the request.
<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
