### PR TITLE
fix(transport): set header when compression is enabled instead of add…

### DIFF
--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -286,7 +286,7 @@ func buildRequest(
 	if isCompressionEnabled {
 		switch c {
 		case compression.GZIP:
-			req.Header.Add("Content-Encoding", "gzip")
+			req.Header.Set("Content-Encoding", "gzip")
 		default:
 			// Do nothing
 		}


### PR DESCRIPTION
…ing a new one

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #742 [CR-5655]
| Need Doc update   | no


## Describe your change

Replace the `.Add()` method on the headers variable by the `.Set()` method to avoid piling up the same header.

## What problem is this fixing?

As stated by some user, the current transporter in Go adds a header each time a request is sent with compression enabled.
Using the `.Set()` method instead fixes the issue.


[CR-5655]: https://algolia.atlassian.net/browse/CR-5655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ