### PR TITLE
Do not return error when trying to unmarshal an empty response body

### DIFF
--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -308,6 +308,9 @@ func unmarshalTo(r io.ReadCloser, v interface{}) error {
 	if err != nil {
 		return fmt.Errorf("cannot read body: %v", err)
 	}
+	if len(body) == 0 {
+		return nil
+	}
 	err = json.Unmarshal(body, &v)
 	if err != nil {
 		return fmt.Errorf("cannot deserialize response's body: %v: %s", err, string(body))

--- a/algolia/transport/transport_test.go
+++ b/algolia/transport/transport_test.go
@@ -96,6 +96,7 @@ func TestUnmarshallTo(t *testing.T) {
 	}{
 		{"<html>Non json answer</html>", fmt.Errorf("cannot deserialize response's body: invalid character '<' looking for beginning of value: <html>Non json answer</html>"), fakeStruct{}},
 		{`{"attr":"value"}`, nil, fakeStruct{"value"}},
+		{"", nil, fakeStruct{}},
 	} {
 		bodyDeserialized := fakeStruct{}
 		err := unmarshalTo(ioutil.NopCloser(bytes.NewReader([]byte(v.bodyRaw))), &bodyDeserialized)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #758  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change
When doing calls like `CreateConfig` and `UpdateConfig` it seems that the response body is empty and the function `unmarshalTo` returns an error. I think an empty body for an api call that does not return anything should not cause an error.

https://www.algolia.com/doc/rest-api/query-suggestions/#create-a-configuration
https://www.algolia.com/doc/rest-api/query-suggestions/#update-a-configuration

Please let me know if this solution makes sense and if it could have any other unwanted consequences.

## What problem is this fixing?
As described in the issue, we are not able to make these API calls successfully because of an error returned from the `unmarshalTo` function which seems to be caused by trying to unmarshal an empty body.