### PR TITLE
feat(search/rule): allow Unmarshaling for structure RuleCondition

### DIFF
--- a/algolia/search/rule_condition.go
+++ b/algolia/search/rule_condition.go
@@ -3,11 +3,11 @@ package search
 import "encoding/json"
 
 type RuleCondition struct {
-	Anchoring    RulePatternAnchoring
-	Pattern      string
-	Context      string
-	Alternatives *Alternatives
-	Filters      string
+	Anchoring    RulePatternAnchoring `json:"anchoring"`
+	Pattern      string               `json:"pattern"`
+	Context      string               `json:"context"`
+	Alternatives *Alternatives        `json:"alternatives"`
+	Filters      string               `json:"filters"`
 }
 
 func (c RuleCondition) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | N/A
| Need Doc update   | no


## Describe your change

Add json struct tags on the structure `RuleCondition` to allow unmarshaling for this structure.
The tag values are matching the official one from the [Search API](https://www.algolia.com/doc/guides/managing-results/rules/rules-overview/#conditions)
