### PR TITLE
feat(insights): implement event optional subtype

### DIFF
--- a/algolia/insights/types.go
+++ b/algolia/insights/types.go
@@ -11,16 +11,22 @@ const (
 	EventTypeView       = "view"
 )
 
+const (
+	EventSubtypePurchase  = "purchase"
+	EventSubtypeAddToCart = "addToCart"
+)
+
 type Event struct {
-	EventType string    `json:"eventType"`
-	EventName string    `json:"eventName"`
-	Index     string    `json:"index"`
-	UserToken string    `json:"userToken"`
-	Timestamp time.Time `json:"-"`
-	ObjectIDs []string  `json:"objectIDs,omitempty"`
-	Positions []int     `json:"positions,omitempty"`
-	QueryID   string    `json:"queryID,omitempty"`
-	Filters   []string  `json:"filters,omitempty"`
+	EventType    string    `json:"eventType"`
+	EventSubtype string    `json:"eventSubtype,omitempty"`
+	EventName    string    `json:"eventName"`
+	Index        string    `json:"index"`
+	UserToken    string    `json:"userToken"`
+	Timestamp    time.Time `json:"-"`
+	ObjectIDs    []string  `json:"objectIDs,omitempty"`
+	Positions    []int     `json:"positions,omitempty"`
+	QueryID      string    `json:"queryID,omitempty"`
+	Filters      []string  `json:"filters,omitempty"`
 }
 
 func (e Event) MarshalJSON() ([]byte, error) {

--- a/algolia/insights/types_test.go
+++ b/algolia/insights/types_test.go
@@ -1,0 +1,72 @@
+package insights
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvent_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    Event
+		expected string
+	}{
+		{
+			name: "Click Event",
+			event: Event{
+				EventType: EventTypeClick,
+				EventName: "foo",
+				Index:     "indexName",
+				UserToken: "bar",
+				Timestamp: time.Date(2024, 5, 31, 21, 30, 0, 0, time.UTC),
+				ObjectIDs: []string{"one", "two"},
+			},
+			expected: `{"timestamp":1717191000000,"eventType":"click","eventName":"foo","index":"indexName","userToken":"bar","objectIDs":["one","two"]}`,
+		},
+		{
+			name: "Conversion Event without subtype",
+			event: Event{
+				EventType: EventTypeConversion,
+				EventName: "foo",
+				Index:     "indexName",
+				UserToken: "bar",
+				Timestamp: time.Date(2024, 5, 31, 21, 30, 0, 0, time.UTC),
+				ObjectIDs: []string{"one", "two"},
+			},
+			expected: `{"timestamp":1717191000000,"eventType":"conversion","eventName":"foo","index":"indexName","userToken":"bar","objectIDs":["one","two"]}`,
+		},
+		{
+			name: "Conversion Event - Purchase",
+			event: Event{
+				EventType:    EventTypeConversion,
+				EventSubtype: EventSubtypePurchase,
+				EventName:    "foo",
+				Index:        "indexName",
+				UserToken:    "bar",
+				Timestamp:    time.Date(2024, 5, 31, 21, 30, 0, 0, time.UTC),
+				ObjectIDs:    []string{"one", "two"},
+			},
+			expected: `{"timestamp":1717191000000,"eventType":"conversion","eventSubtype":"purchase","eventName":"foo","index":"indexName","userToken":"bar","objectIDs":["one","two"]}`,
+		},
+		{
+			name: "Event with zero timestamp",
+			event: Event{
+				EventType: EventTypeView,
+				EventName: "foo",
+				Index:     "indexName",
+				UserToken: "bar",
+			},
+			expected: `{"eventType":"view","eventName":"foo","index":"indexName","userToken":"bar"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bytes, err := tt.event.MarshalJSON()
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(bytes))
+		})
+	}
+}

--- a/algolia/insights/user_client.go
+++ b/algolia/insights/user_client.go
@@ -69,6 +69,38 @@ func (c *UserClient) ConvertedObjectIDs(
 	}, opts...)
 }
 
+func (c *UserClient) ConvertedObjectIDsPurchase(
+	eventName string,
+	indexName string,
+	objectIDs []string,
+	opts ...interface{},
+) (StatusMessageRes, error) {
+	return c.Client.SendEvent(Event{
+		UserToken:    c.UserToken,
+		EventType:    EventTypeConversion,
+		EventSubtype: EventSubtypePurchase,
+		EventName:    eventName,
+		Index:        indexName,
+		ObjectIDs:    objectIDs,
+	}, opts...)
+}
+
+func (c *UserClient) ConvertedObjectIDsAddToCart(
+	eventName string,
+	indexName string,
+	objectIDs []string,
+	opts ...interface{},
+) (StatusMessageRes, error) {
+	return c.Client.SendEvent(Event{
+		UserToken:    c.UserToken,
+		EventType:    EventTypeConversion,
+		EventSubtype: EventSubtypeAddToCart,
+		EventName:    eventName,
+		Index:        indexName,
+		ObjectIDs:    objectIDs,
+	}, opts...)
+}
+
 func (c *UserClient) ConvertedObjectIDsAfterSearch(
 	eventName string,
 	indexName string,
@@ -84,7 +116,42 @@ func (c *UserClient) ConvertedObjectIDsAfterSearch(
 		ObjectIDs: objectIDs,
 		QueryID:   queryID,
 	}, opts...)
+}
 
+func (c *UserClient) ConvertedObjectIDsAfterSearchPurchase(
+	eventName string,
+	indexName string,
+	objectIDs []string,
+	queryID string,
+	opts ...interface{},
+) (StatusMessageRes, error) {
+	return c.Client.SendEvent(Event{
+		UserToken:    c.UserToken,
+		EventType:    EventTypeConversion,
+		EventSubtype: EventSubtypePurchase,
+		EventName:    eventName,
+		Index:        indexName,
+		ObjectIDs:    objectIDs,
+		QueryID:      queryID,
+	}, opts...)
+}
+
+func (c *UserClient) ConvertedObjectIDsAfterSearchAddToCart(
+	eventName string,
+	indexName string,
+	objectIDs []string,
+	queryID string,
+	opts ...interface{},
+) (StatusMessageRes, error) {
+	return c.Client.SendEvent(Event{
+		UserToken:    c.UserToken,
+		EventType:    EventTypeConversion,
+		EventSubtype: EventSubtypeAddToCart,
+		EventName:    eventName,
+		Index:        indexName,
+		ObjectIDs:    objectIDs,
+		QueryID:      queryID,
+	}, opts...)
 }
 
 func (c *UserClient) ConvertedFilters(
@@ -99,6 +166,38 @@ func (c *UserClient) ConvertedFilters(
 		EventName: eventName,
 		Index:     indexName,
 		Filters:   filters,
+	}, opts...)
+}
+
+func (c *UserClient) ConvertedFiltersPurchase(
+	eventName string,
+	indexName string,
+	filters []string,
+	opts ...interface{},
+) (StatusMessageRes, error) {
+	return c.Client.SendEvent(Event{
+		UserToken:    c.UserToken,
+		EventType:    EventTypeConversion,
+		EventSubtype: EventSubtypePurchase,
+		EventName:    eventName,
+		Index:        indexName,
+		Filters:      filters,
+	}, opts...)
+}
+
+func (c *UserClient) ConvertedFiltersAddToCart(
+	eventName string,
+	indexName string,
+	filters []string,
+	opts ...interface{},
+) (StatusMessageRes, error) {
+	return c.Client.SendEvent(Event{
+		UserToken:    c.UserToken,
+		EventType:    EventTypeConversion,
+		EventSubtype: EventSubtypeAddToCart,
+		EventName:    eventName,
+		Index:        indexName,
+		Filters:      filters,
 	}, opts...)
 }
 

--- a/cts/insights/sending_events_test.go
+++ b/cts/insights/sending_events_test.go
@@ -93,13 +93,49 @@ func TestSendingEvents(t *testing.T) {
 	}
 
 	{
+		res, err := insightsUserClient.ConvertedObjectIDsPurchase("foo", indexName, []string{"one", "two"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.Status)
+	}
+
+	{
+		res, err := insightsUserClient.ConvertedObjectIDsAddToCart("foo", indexName, []string{"one", "two"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.Status)
+	}
+
+	{
 		res, err := insightsUserClient.ConvertedObjectIDsAfterSearch("foo", indexName, []string{"one", "two"}, queryID)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.Status)
 	}
 
 	{
+		res, err := insightsUserClient.ConvertedObjectIDsAfterSearchPurchase("foo", indexName, []string{"one", "two"}, queryID)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.Status)
+	}
+
+	{
+		res, err := insightsUserClient.ConvertedObjectIDsAfterSearchAddToCart("foo", indexName, []string{"one", "two"}, queryID)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.Status)
+	}
+
+	{
 		res, err := insightsUserClient.ConvertedFilters("foo", indexName, []string{"filter:foo", "filter:bar"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.Status)
+	}
+
+	{
+		res, err := insightsUserClient.ConvertedFiltersPurchase("foo", indexName, []string{"filter:foo", "filter:bar"})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.Status)
+	}
+
+	{
+		res, err := insightsUserClient.ConvertedFiltersAddToCart("foo", indexName, []string{"filter:foo", "filter:bar"})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.Status)
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | Fix #749 [CR-6348]
| Need Doc update   | no


## Describe your change

Add the optional subtype property to the Event struct for Insights

## What problem is this fixing?

Users couldn't send an event subtype


[CR-6348]: https://algolia.atlassian.net/browse/CR-6348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ