### PR TITLE
update reference to support@algolia.com to new ticket link

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -766,9 +766,7 @@ types that were wrong.
 As usual, feel free to report any issue of question you may have in our [Github
 issue tracker](https://github.com/algolia/algoliasearch-client-go/issues) and
 to contribute by submitting your Pull Requests directly to [our Github
-repository](https://github.com/algolia/algoliasearch-client-go/pulls). And for
-a more detailed assistance regarding Algolia and its features, you may also
-contact us directly at support@algolia.com.
+repository](https://github.com/algolia/algoliasearch-client-go/pulls). And for more detailed assistance regarding Algolia and its features, please reach out to the [Algolia Support Team](https://alg.li/support).
 
 Have a nice day.
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no  
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

Hey team!
The Support team is currently in a process of removing support@algolia.com email from all GitHub repos and updating it to link to the create support ticket form. We kindly ask that you review the changes made removing references to support@algolia.com
Thanks!


