### PR TITLE
feat(specs): add (optional) _automaticInsights to search result

### DIFF
--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -43,6 +43,7 @@ type QueryRes struct {
 	ABTestVariantID            int                               `json:"abTestVariantID"`
 	ABTestID                   uint32                            `json:"abTestID"`
 	RenderingContent           *RenderingContent                 `json:"renderingContent"`
+	AutomaticInsights          *bool                             `json:"_automaticInsights,omitempty"`
 }
 
 type AppliedRule struct {


### PR DESCRIPTION
## 🧭 What and Why

Porting this PR to v3 : https://github.com/algolia/api-clients-automation/pull/3688

Return the parameter `_automaticInsights` (when possible) when calling search.


# Why 

I need this value in the Recommend mono-repository so that the Recommend API can forward this parameter to the Recommend client.
