### PR TITLE
fix(insights): add missing props

### DIFF
--- a/algolia/insights/types.go
+++ b/algolia/insights/types.go
@@ -16,17 +16,28 @@ const (
 	EventSubtypeAddToCart = "addToCart"
 )
 
+type ObjectData struct {
+	Discount interface{} `json:"discount,omitempty"`
+	Price    interface{} `json:"price,omitempty"`
+	Quantity int32       `json:"quantity,omitempty"`
+	QueryID  *string     `json:"queryID,omitempty"`
+}
+
 type Event struct {
-	EventType    string    `json:"eventType"`
-	EventSubtype string    `json:"eventSubtype,omitempty"`
-	EventName    string    `json:"eventName"`
-	Index        string    `json:"index"`
-	UserToken    string    `json:"userToken"`
-	Timestamp    time.Time `json:"-"`
-	ObjectIDs    []string  `json:"objectIDs,omitempty"`
-	Positions    []int     `json:"positions,omitempty"`
-	QueryID      string    `json:"queryID,omitempty"`
-	Filters      []string  `json:"filters,omitempty"`
+	EventName              string       `json:"eventName"`
+	EventType              string       `json:"eventType"`
+	EventSubtype           string       `json:"eventSubtype,omitempty"`
+	Index                  string       `json:"index"`
+	ObjectIDs              []string     `json:"objectIDs,omitempty"`
+	Positions              []int        `json:"positions,omitempty"`
+	QueryID                string       `json:"queryID,omitempty"`
+	UserToken              string       `json:"userToken"`
+	AuthenticatedUserToken *string      `json:"authenticatedUserToken"`
+	Currency               *string      `json:"currency,omitempty"`
+	ObjectData             []ObjectData `json:"objectData,omitempty"`
+	Timestamp              time.Time    `json:"-"`
+	Filters                []string     `json:"filters,omitempty"`
+	Value                  interface{}  `json:"value,omitempty"`
 }
 
 func (e Event) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## What
Add missing props to the Insights event type

## Note
Some props are not strongly typed because they can be multiple things (usually string or number)
In the future, we should allow extracting data from the opts variadic param

fixes #767 